### PR TITLE
Add Claude Code project configuration and Atlassian MCP integration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,134 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__atlassian__getJiraIssue",
+      "mcp__atlassian__searchJiraIssuesUsingJql",
+      "mcp__atlassian__getVisibleJiraProjects",
+      "mcp__atlassian__getJiraProjectIssueTypesMetadata",
+      "mcp__atlassian__getJiraIssueTypeMetaWithFields",
+      "mcp__atlassian__getTransitionsForJiraIssue",
+      "mcp__atlassian__getJiraIssueRemoteIssueLinks",
+      "mcp__atlassian__getIssueLinkTypes",
+      "mcp__atlassian__lookupJiraAccountId",
+      "mcp__atlassian__atlassianUserInfo",
+      "mcp__atlassian__getAccessibleAtlassianResources",
+      "mcp__atlassian__searchConfluenceUsingCql",
+      "mcp__atlassian__getConfluencePage",
+      "mcp__atlassian__getPagesInConfluenceSpace",
+      "mcp__atlassian__getConfluenceSpaces",
+      "mcp__atlassian__getConfluencePageDescendants",
+      "mcp__atlassian__getConfluencePageFooterComments",
+      "mcp__atlassian__getConfluencePageInlineComments",
+      "mcp__atlassian__getConfluenceCommentChildren",
+
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git ls-files:*)",
+      "Bash(git fetch:*)",
+      "Bash(git branch)",
+      "Bash(git remote -v)",
+
+      "Bash(git switch -c:*)",
+      "Bash(git checkout -b:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)",
+
+      "Bash(yarn lint)",
+      "Bash(yarn tsc)",
+      "Bash(yarn test:*)"
+    ],
+
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr edit:*)",
+      "Bash(gh pr ready:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh api:*)",
+
+      "Bash(yarn db:schema)",
+      "Bash(yarn db:schema *)",
+      "Edit(package.json)",
+      "Edit(yarn.lock)",
+      "Edit(package-lock.json)",
+
+      "mcp__atlassian__createJiraIssue",
+      "mcp__atlassian__editJiraIssue",
+      "mcp__atlassian__transitionJiraIssue",
+      "mcp__atlassian__addCommentToJiraIssue",
+      "mcp__atlassian__createIssueLink",
+
+      "mcp__atlassian__createConfluencePage",
+      "mcp__atlassian__updateConfluencePage",
+      "mcp__atlassian__createConfluenceFooterComment",
+      "mcp__atlassian__createConfluenceInlineComment"
+    ],
+
+    "deny": [
+      "Read(.env)",
+      "Read(.env.*)",
+      "Edit(.env)",
+      "Write(.env)",
+
+      "mcp__atlassian__addWorklogToJiraIssue",
+      "mcp__atlassian__createCompassComponent",
+      "mcp__atlassian__createCompassComponentRelationship",
+      "mcp__atlassian__createCompassCustomFieldDefinition",
+      "mcp__atlassian__addTeamworkGraphContext",
+
+      "Bash(gh pr merge:*)",
+      "Bash(gh api -X PUT:*)",
+      "Bash(gh api -X POST:*)",
+      "Bash(gh api -X PATCH:*)",
+      "Bash(gh api -X DELETE:*)",
+      "Bash(gh api --method PUT:*)",
+      "Bash(gh api --method POST:*)",
+      "Bash(gh api --method PATCH:*)",
+      "Bash(gh api --method DELETE:*)",
+
+      "Bash(git add -A:*)",
+      "Bash(git add --all:*)",
+      "Bash(git add .)",
+      "Bash(git add :/)",
+      "Bash(git commit -a:*)",
+      "Bash(git commit --all:*)",
+      "Bash(git commit -am:*)",
+
+      "Bash(git push origin main:*)",
+      "Bash(git push origin staging:*)",
+      "Bash(git push -u origin main:*)",
+      "Bash(git push -u origin staging:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+
+      "Bash(yarn seed:*)",
+      "Bash(yarn run seed:*)",
+      "Bash(yarn prisma db seed:*)",
+      "Bash(npx prisma db seed:*)",
+      "Bash(prisma db seed:*)",
+      "Bash(yarn build:preview)",
+      "Bash(yarn build:preview *)",
+      "Bash(yarn run build:preview)",
+      "Bash(yarn run build:preview *)",
+      "Bash(yarn prisma db push:*)",
+      "Bash(npx prisma db push:*)",
+      "Bash(prisma db push:*)",
+      "Bash(yarn prisma migrate reset:*)",
+      "Bash(npx prisma migrate reset:*)",
+      "Bash(prisma migrate reset:*)",
+
+      "Bash(python scripts/emailtemplate.py:*)",
+      "Bash(python3 scripts/emailtemplate.py:*)"
+    ]
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp/authv2"
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,74 @@ There are no test files yet. Jest uses the `ts-jest` preset with the default `no
 - Env vars are validated with `envsafe` at import time; missing required values can prevent startup. `NEXTAUTH_SECRET` has a development default. AWS keys use **suffixed** names — `ACCESS_KEY_ID_AWS`, `SECRET_ACCESS_KEY_AWS`, `REGION_AWS`; standard `AWS_*` names fail validation. Full list in the README.
 - Five UI systems coexist (Tailwind, Headless UI, MUI, Ant Design, styled-components). Use the one already present in the file being edited; do not add a sixth.
 
+## External knowledge — Confluence and Jira
+
+Reached through the `atlassian` MCP server. Reads are fine when relevant; writes
+follow the rules below and in **Work tracking**.
+
+- **Confluence** is the authoritative home for long-form team, engineering,
+  infrastructure, operational, and process documentation — deployment, AWS,
+  PlanetScale, environment setup, PRDs, research. Little of it is in this repo.
+- **Jira project `SCRUM`** ("Carpool Main") tracks work. When a request references
+  `SCRUM-###`, retrieve that issue before acting.
+- Search Confluence only when a task needs knowledge this repo does not contain,
+  and fetch the specific pages needed — not whole spaces.
+- Tickets define **what** should change; this repo and its READMEs define **how**
+  the code works today. Tickets are often thin — never invent missing scope, ask.
+- Confluence pages may be stale. Verify technical claims against the code.
+- Jira and Confluence writes are available. Use them when the current task is
+  explicitly about project management or documentation, when **Work tracking**
+  below authorizes it, or when an established workflow does — never as an
+  unannounced side effect. Say what you changed.
+
+## Work tracking
+
+Jira project `SCRUM` is the source of truth for engineering work, and meaningful
+work should be associated with an issue.
+
+When you discover an actionable bug, regression, tech-debt item, or follow-up
+during development: **search Jira first** — if a matching issue exists, reference
+it rather than filing a duplicate. If none exists and the problem is outside the
+current task's scope, create the issue. Filing it is authorized; you do not need
+to be asked.
+
+**Do not widen the current change or PR to fix an unrelated discovery.** Track it
+in Jira and stay on the active ticket.
+
+Give a new issue the evidence you have: affected area, observed vs. expected
+behavior, impact, relevant paths, and the ticket you were on when you found it.
+Do not file trivial observations, speculation, or anything the active ticket
+already covers.
+
+## Git and GitHub
+
+**GitHub branch protection on `main` is UNVERIFIED** — the current developer
+cannot access repository Settings, so its configuration has not been confirmed
+either way. Assume nothing rejects a bad push server-side: these rules and
+`.claude/settings.json` are the only protection you can rely on.
+
+Implementation work happens on a feature branch off a freshly fetched
+`origin/main`, and pull requests target `main`. Use `staging` only if the
+current team workflow explicitly requires it.
+
+**Before every commit and every push, run `git rev-parse --abbrev-ref HEAD`.** If
+it returns `main` or `staging`, stop and say so — do not commit, do not push.
+
+You may create and update feature branches, commit and push them, create and
+update pull requests against `main`, and inspect PR checks and status.
+
+**Your workflow ends at the pull request.** Report the PR and its check status,
+then stop. Never merge a PR, and never move a ticket to `Done` — both follow the
+merge, and the user performs every merge manually through GitHub.
+
+- Never commit implementation work to `main` or `staging`, and never push either
+  branch.
+- Never test branch protection by pushing to `main`. Local `main` may be ahead of
+  `origin/main`, so a "test" push can land real commits.
+- Stage specific paths. Never `git add -A` or `git commit -a` — the working tree
+  may hold unrelated changes that must stay out of the commit and PR.
+- Never force-push a shared branch or bypass branch protection.
+
 ## References
 
 - [`README.md`](README.md) — setup and the full environment variable list


### PR DESCRIPTION
Sets up Claude Code for this repository: project guidance, tool permissions, and
the Atlassian MCP server. Documentation and configuration only — no application
code, dependencies, or lockfile changes.

## What's included

**Claude Code project configuration (`CLAUDE.md`, `.claude/settings.json`)**

`CLAUDE.md` already covered the stack, commands, architecture, data-model
gotchas, and safety rules around destructive database commands and
side-effecting external services (SES, Pusher, Mapbox). This adds the workflow
sections below.

`.claude/settings.json` encodes those rules as enforced tool permissions rather
than prose alone:
- **allow** — read-only git/`gh` inspection, Jira/Confluence reads, `yarn lint`,
  `yarn tsc`, `yarn test`, branch creation, staging, and committing.
- **ask** — anything that leaves the machine or mutates shared state: `git push`,
  PR create/edit/comment, `gh api`, Jira/Confluence writes, and edits to
  `package.json` / `yarn.lock` / `package-lock.json`.
- **deny** — reading or writing `.env`, `gh pr merge`, mutating `gh api` verbs,
  `git add -A` / `git commit -a`, pushes to `main` or `staging`, force pushes,
  and the data-destroying scripts (`yarn seed`, `yarn build:preview`,
  `prisma db push`, `prisma migrate reset`, `scripts/emailtemplate.py`).

**Atlassian MCP configuration (`.mcp.json`)**

Registers the hosted Atlassian MCP server (`https://mcp.atlassian.com/v1/mcp/authv2`)
over HTTP. Auth is handled by the server's OAuth flow — no tokens, keys, or
credentials are stored in the repo.

**Jira/Confluence workflow**

Confluence is the authoritative home for long-form team, infrastructure, and
process documentation that does not live in this repo; Jira project `SCRUM`
tracks the work. Tickets define *what* to change while the repo defines *how*
the code works today, Confluence pages may be stale and get verified against the
code, and Claude searches Jira before filing anything so it references existing
issues instead of creating duplicates. Discoveries outside the current task's
scope get tracked in Jira rather than widening the active PR.

**Git/GitHub safety rules**

Branch protection on `main` is currently **unverified** — the current developer
cannot access repository Settings, so nothing is assumed to reject a bad push
server-side, which is why these rules and the permission list exist. Claude
verifies the branch with `git rev-parse --abbrev-ref HEAD` before every commit
and every push and stops if it is on `main` or `staging`, stages explicit paths
instead of `git add -A`, and never force-pushes a shared branch. Implementation
work happens on a feature branch off a freshly fetched `origin/main` with PRs
targeting `main`; `staging` is used only if the current team workflow explicitly
requires it.

**Claude's workflow stops at the PR**

Claude may create branches, commit, push, open and update PRs, and report check
status — and then it stops. It never merges a PR and never moves a Jira ticket
to `Done`, since both follow the merge. **Every merge is performed manually by a
human through GitHub.**

## Validation

This PR was produced end-to-end through the workflow it documents, as its first
real test: branch verified before commit and before push, only the three
intended files staged, staged diff reviewed and scanned for secrets, and the
unrelated `yarn.lock` modification in the working tree deliberately left
unstaged and uncommitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
