### PR TITLE
SCRUM-217: Add jira-ticket Claude Code Skill for the engineering workflow

### DIFF
--- a/.claude/skills/jira-ticket/SKILL.md
+++ b/.claude/skills/jira-ticket/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: jira-ticket
+description: Execute a NUCarpool engineering ticket through the Jira-first workflow, from establishing the Jira issue to a review-ready pull request. Use when the user asks to work on, implement, pick up, continue, or finish a SCRUM ticket ("work on SCRUM-215", "implement SCRUM-217", "complete SCRUM-220 through PR readiness"), or asks for meaningful engineering or documentation work that should be tracked in Jira. Covers Jira status transitions, feature-branch and commit discipline, PR creation, and the post-PR CI fix loop. Claude owns delivery through PR readiness; the human owns the merge.
+---
+
+# Executing a NUCarpool engineering ticket
+
+You own the work **through PR readiness**. The human owns the **merge**. Creating a PR is not
+the finish line.
+
+## Where truth lives — read, don't restate
+
+| Source                                                                                                | Authority                                                                  |
+| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| [`CLAUDE.md`](../../../CLAUDE.md)                                                                     | Permanent project rules, safety boundaries, commands, architecture gotchas |
+| [`.claude/settings.json`](../../settings.json)                                                        | Tool permissions (allow / ask / deny) — the only permission authority      |
+| Jira issue                                                                                            | Live requirements and acceptance criteria                                  |
+| Repository + READMEs                                                                                  | How the code actually works today                                          |
+| Confluence (space `CNCS`)                                                                             | Deeper architecture, infra, deployment, process, product history           |
+| [`docs/development/AI_DEVELOPMENT_WORKFLOW.md`](../../../docs/development/AI_DEVELOPMENT_WORKFLOW.md) | The human-facing explanation of this system                                |
+
+Do not copy the tech stack, data model, environment variables, or permission lists into your
+reasoning output — consult them where they live.
+
+## 1. Establish the Jira issue — always first
+
+No implementation begins as an anonymous, untracked change.
+
+- **Given a key** (`SCRUM-###`): retrieve it before acting. Read the description and
+  acceptance criteria. If it is thin, reconstruct scope from the repo — never invent it. Ask
+  when a genuine ambiguity would change the work.
+- **No key given**, and the request is meaningful project work: **search Jira first** with a
+  couple of phrasings. Use an existing issue if one matches; otherwise create one describing
+  the goal, then proceed.
+- **Trivial actions** — answering a question, reading code, a one-line typo, exploratory
+  investigation — do not need a ticket. Use judgment; do not manufacture bureaucracy.
+
+## 2. Transition to In Progress
+
+Once you begin real investigation, implementation, or documentation work, transition the issue
+to `In Progress`. Creating or merely reading a ticket does not move it.
+
+**Resolve every transition by workflow status name, never a hard-coded transition ID.** Fetch
+the issue's available transitions and match on the name — IDs are project configuration and
+can change.
+
+## 3. Investigate before editing
+
+Ticket → repository → _then_ decide whether outside knowledge is needed.
+
+Read the code and the relevant READMEs first. Reach for Confluence **only** when the task needs
+knowledge the repo does not contain — architecture, infrastructure, deployment, operational
+procedure, team process, or product history. Fetch the specific pages, not whole spaces.
+
+Confluence can be stale. Verify any technical claim against the current code; where they
+disagree, the code wins.
+
+## 4. Feature branch
+
+Before switching branches, inspect the working tree. Identify pre-existing changes that are
+not yours. **Never discard them, and never silently include them in your commit.** Name them
+in your report.
+
+Branch off a freshly fetched `origin/main`. Reuse the existing branch if the ticket is already
+underway on one.
+
+## 5. Implement
+
+Stay inside the ticket. Match the conventions of the file you are editing.
+
+## 6. Validate
+
+Run what the change warrants — normally `yarn lint` and `yarn tsc`, plus `yarn test` where
+relevant, and any task-specific checks (for docs: formatting, link and anchor resolution, a
+secrets scan).
+
+**Report test results honestly.** There is currently no test suite, so `yarn test` passes
+because nothing runs. That is a vacuous pass, not coverage — never present it as coverage.
+
+Failure caused by your change → fix it and revalidate. Failure that is unrelated → the
+discovered-issue workflow below; do not expand scope.
+
+## 7. Self-review before staging
+
+Read the complete diff and check:
+
+- every change belongs to this ticket
+- no unrelated file crept in
+- no secrets, credentials, tokens, `.env` values, personal paths, or machine-specific data
+- nothing dangerous or unintended was introduced
+- the work actually satisfies the acceptance criteria
+
+If criteria remain unmet, say so plainly. Do not claim completion you have not reached.
+
+## 8. Stage and commit
+
+**Run `git rev-parse --abbrev-ref HEAD` immediately before committing.** If it returns `main`
+or `staging`, stop and say so.
+
+Stage explicit paths only. Never `git add .`, `git add -A`, `git add --all`, `git commit -a`,
+or `git commit -am` — the working tree may hold changes that must stay out.
+
+Inspect `git diff --cached` before committing. Write a concise message that references the
+Jira key and explains _why_, not just _what_.
+
+## 9. Push
+
+**Verify the branch again immediately before pushing.** Push only the feature branch. Never
+push `main` or `staging`. Never force-push.
+
+## 10. Create or update the PR
+
+Target `main`. If a PR already exists for the branch, **update it rather than opening a
+duplicate**.
+
+Include: the Jira link, purpose, relevant acceptance criteria, major changes, validation
+performed, known limitations and risks, related issues discovered during the work, and an
+explicit note about any pre-existing changes deliberately excluded.
+
+## 11. Transition to Code Review
+
+**Only after confirming the branch is pushed and the PR actually exists.** Verify, then
+transition to `Code Review` and comment on the issue with:
+
+- the PR link
+- a concise summary of what changed
+- validation performed
+- any Jira issues discovered during the work
+
+No PR means no `Code Review`.
+
+## 12. Own the PR until it is ready
+
+PR creation is not the endpoint. Inspect the PR's files, final diff, base and head branches,
+and checks. Confirm it contains only intended changes, and verify acceptance criteria against
+what actually shipped.
+
+When a check fails **because of this ticket**:
+
+```
+diagnose → fix → validate → review diff → stage targeted → commit → push SAME branch → re-check
+```
+
+Never open a second PR to fix the first. Repeat while it is reasonably productive. If checks
+are still running, wait for them rather than declaring readiness early.
+
+Unrelated failure → discovered-issue workflow, and do not pull the fix into this PR. If an
+unrelated failure genuinely blocks review-readiness, use `Blocked`.
+
+## Stop conditions
+
+Stop in exactly one of two states, and report which:
+
+**A. Review-ready PR** — intended work present, unrelated changes absent, validation passing,
+checks understood, acceptance criteria satisfied or gaps explicitly reported, Jira in
+`Code Review` with the PR link attached.
+
+**B. Genuinely blocked** — Jira in `Blocked` and accurately explaining the situation.
+
+Then stop. The human reviews and merges.
+
+## Discovered-issue workflow
+
+When you find a new actionable problem mid-task:
+
+1. Is it part of the active ticket? If yes, handle it in scope.
+2. If not — **do not scope-creep the current PR.** Search Jira first, with more than one
+   phrasing if the wording is uncertain.
+3. Match found → reference it.
+4. No match → create an issue carrying the evidence you have: affected area, observed vs.
+   expected behavior, impact, relevant paths, and the ticket you were on when you found it.
+5. Return to the original task.
+
+Do not file trivial observations, speculation, duplicates, or anything the active ticket
+already covers.
+
+## Blocked
+
+`Blocked` is an exception state, not a slower `In Progress`. Use it only when useful progress
+genuinely cannot continue: missing access, an external dependency, a required human or team
+decision, unavailable required information, or a comparable blocker.
+
+Investigate first. If the answer is discoverable in the repo, Jira, Confluence, or git
+history, that is research — do the research. Do not use `Blocked` for ordinary uncertainty.
+
+When blocking: transition to `Blocked` and comment with **what is blocking the work** and
+**what is needed to resume**. When it clears, transition back to `In Progress` and continue.
+
+## Never
+
+- merge a PR — not `gh pr merge`, not a GitHub API mutation, not the web UI
+- push or commit to `main` or `staging`
+- force-push, or bypass branch protection
+- transition an issue to `Done` — that follows the human merge
+- work around the permission system
+
+## Permissions
+
+[`.claude/settings.json`](../../settings.json) is the source of truth and is deliberately
+restrictive. Read-only inspection generally runs freely; pushes, PR writes, and Jira and
+Confluence writes prompt; merges and destructive database commands are denied.
+
+When an action needs approval, request it normally and wait. A declined prompt means _don't_ —
+adjust the approach; never reach for another route to the same effect. Never weaken, bypass,
+or edit permissions to make a task easier.

--- a/docs/development/AI_DEVELOPMENT_WORKFLOW.md
+++ b/docs/development/AI_DEVELOPMENT_WORKFLOW.md
@@ -63,14 +63,15 @@ Three ideas carry the design:
 
 ## 3. Repository configuration files
 
-| File                                                   | Role                                                                                                    | In git |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- | ------ |
-| [`CLAUDE.md`](../../CLAUDE.md)                         | Durable project instructions: commands, architecture gotchas, safety, git policy. Loaded every session. | yes    |
-| [`.claude/settings.json`](../../.claude/settings.json) | Permission model: allowed / prompted / forbidden tools. **Source of truth.**                            | yes    |
-| `.claude/settings.local.json`                          | Your machine-local overrides. Personal.                                                                 | no     |
-| [`.mcp.json`](../../.mcp.json)                         | Declares the Atlassian MCP server. URL only — no credentials.                                           | yes    |
-| [`README.md`](../../README.md)                         | Human setup: stack, environment variables, commands.                                                    | yes    |
-| [`.github/workflows/`](../../.github/workflows/)       | CI — see [§14](#14-ci-behavior).                                                                        | yes    |
+| File                                                                               | Role                                                                                                    | In git |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------ |
+| [`CLAUDE.md`](../../CLAUDE.md)                                                     | Durable project instructions: commands, architecture gotchas, safety, git policy. Loaded every session. | yes    |
+| [`.claude/settings.json`](../../.claude/settings.json)                             | Permission model: allowed / prompted / forbidden tools. **Source of truth.**                            | yes    |
+| `.claude/settings.local.json`                                                      | Your machine-local overrides. Personal.                                                                 | no     |
+| [`.claude/skills/jira-ticket/SKILL.md`](../../.claude/skills/jira-ticket/SKILL.md) | The repeatable procedure for executing a ticket — see [§10](#10-standard-engineering-lifecycle).        | yes    |
+| [`.mcp.json`](../../.mcp.json)                                                     | Declares the Atlassian MCP server. URL only — no credentials.                                           | yes    |
+| [`README.md`](../../README.md)                                                     | Human setup: stack, environment variables, commands.                                                    | yes    |
+| [`.github/workflows/`](../../.github/workflows/)                                   | CI — see [§14](#14-ci-behavior).                                                                        | yes    |
 
 Layer-specific docs: [`src/server/router/README.md`](../../src/server/router/README.md)
 (tRPC routers, context, auth) and [`src/server/db/README.md`](../../src/server/db/README.md)
@@ -238,6 +239,13 @@ editing a PR prompts you. Merging is blocked outright.
 > output lands in the conversation.
 
 ## 10. Standard engineering lifecycle
+
+> **This lifecycle is executable.** The step-by-step procedure lives in the
+> [`jira-ticket` Skill](../../.claude/skills/jira-ticket/SKILL.md), which Claude Code invokes
+> when you ask it to work on a ticket ("work on SCRUM-215"). This section explains the shape
+> and the reasoning; the Skill is what actually runs. Keeping them separate is deliberate —
+> three layers, three jobs: **CLAUDE.md** holds permanent rules, **`.claude/settings.json`**
+> holds permissions, and the **Skill** holds the repeatable procedure.
 
 ```
 establish Jira issue    ← FIRST. work is never anonymous          [To Do]


### PR DESCRIPTION
## Jira ticket

[SCRUM-217](https://carpoolnu.atlassian.net/browse/SCRUM-217) — Create a jira-ticket Claude Code Skill for the engineering workflow

Follows [SCRUM-215](https://carpoolnu.atlassian.net/browse/SCRUM-215), which documented this workflow for humans.

## Purpose

The Jira-first engineering workflow has been exercised end to end and is stable, but it lived only in long ad-hoc prompts. That meant re-specifying it by hand on every run, with drift between runs. This moves the repeatable procedure into a Claude Code Skill, so an ordinary request — "work on SCRUM-###" — invokes the same disciplined workflow every time.

## Major changes

| File | Change |
|---|---|
| `.claude/skills/jira-ticket/SKILL.md` | **New**, 205 lines |
| `docs/development/AI_DEVELOPMENT_WORKFLOW.md` | +16/−8 — one config-table row, one note at §10 |

The Skill runs: establish the Jira issue → `In Progress` → investigate repo-first → branch off freshly fetched `origin/main` → implement → validate → self-review → targeted staging → commit → push → create/update PR → `Code Review` **only once the PR exists** → post-PR CI inspect-and-fix loop on the same branch → verify criteria → stop at review readiness.

It also encodes the judgment that is easiest to lose between sessions:

- **`Blocked` is an exception state**, not a slower `In Progress`. Investigate first; requires a comment stating the blocker and what is needed to resume.
- **Transitions resolve by workflow status name**, never a hard-coded transition ID.
- **Discovered problems** get a Jira duplicate search, then a reference or a new issue — never a wider PR.
- **Confluence** is consulted only when the repo lacks the knowledge, and its technical claims are verified against the code.
- **Test results are reported honestly** — there is no test suite, so a passing `yarn test` is a vacuous pass, not coverage.
- **Claude never merges and never sets `Done`.** The merge is the human boundary.

## Acceptance criteria

All 20 criteria from the ticket were verified against the Skill text: correct path and trigger phrasings, Jira established before implementation, supplied keys retrieved before acting, duplicate search when no key is given, no tickets for trivial work, status-name transitions, `Blocked` semantics and comment contents, `Code Review` gated on an existing PR, `Code Review` comment contents, never `Done`, discovered-issue workflow without scope creep, resuming the original task afterward, progressive Confluence use with staleness caveat, branch verification, targeted staging only, post-PR same-branch fix loop, no second PR for fixes, no merging by any route, and working with `.claude/settings.json` without duplicating or weakening it.

## Progressive disclosure

Three layers stay separate rather than being restated:

- **`CLAUDE.md`** — permanent project rules and boundaries
- **`.claude/settings.json`** — tool permissions (the only permission authority)
- **`.claude/skills/jira-ticket/SKILL.md`** — the repeatable procedure

Verified absent from the Skill: permission patterns (**0** occurrences vs 69 in `settings.json`), tech stack, data model, environment variables, and Confluence content. Only pointers to where each already lives.

## Validation performed

- Prettier clean on both files; YAML frontmatter parses with `name` and `description`
- All 3 Skill relative links resolve; all guide links and internal anchors resolve
- Secret / credential / token / personal-path scan: clean
- No contradictions with `CLAUDE.md`; the Skill's prohibitions are a restatement, adding no capability and granting no permission
- `yarn lint` clean · `yarn tsc` clean · `yarn test --passWithNoTests` exits 0 with **zero test files present** (vacuous pass, not coverage)

## Known limitations / risks

- A Skill created mid-session is not registered in that session; it takes effect in new Claude Code sessions once this lands.
- The Skill is prose guidance, not a mechanical guarantee. `.claude/settings.json` remains the only real enforcement layer.
- Branch protection on `main` is still unverified (no admin access to repository Settings).
- No test suite exists, so `test.yml` remains a placeholder in practice.

## Related Jira issues

- **SCRUM-216** — `.claude/settings.local.json` missing from repository `.gitignore` (open, unrelated to this PR)
- Husky v10 and `next lint` (Next 16) deprecation warnings surface during local runs; both fall under existing **SCRUM-136**, referenced rather than duplicated, and deliberately not fixed here

## Scope confirmation

Documentation and configuration-procedure only. No application code, Prisma/schema, dependency, `.claude/settings.json`, `.mcp.json`, or CI workflow changes.

**The pre-existing unrelated `yarn.lock` modification is excluded.** Its blob hash was captured before and after branching and is unchanged; it remains modified and unstaged in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)