### PR TITLE
SCRUM-218: Make the discovered-issue workflow intent-aware (find vs find-and-fix)

### DIFF
--- a/.claude/skills/jira-ticket/SKILL.md
+++ b/.claude/skills/jira-ticket/SKILL.md
@@ -22,6 +22,20 @@ the finish line.
 Do not copy the tech stack, data model, environment variables, or permission lists into your
 reasoning output — consult them where they live.
 
+## 0. Read what the request authorizes
+
+Filing a ticket and fixing a problem are different acts. Decide which the user asked for
+**before** you touch anything, because it determines ticket status.
+
+| Request               | Example                                                           | You do                                                                                                                                  |
+| --------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Find / audit only** | "find problems in the messaging system", "audit this for bugs"    | Investigate. File or reference issues. Leave new ones in `To Do`. **Do not start fixing.** Keep auditing, then report.                  |
+| **Find and fix**      | "find problems and fix them", "audit X and resolve what you find" | Investigate. Establish the issue. Make it active, move it to `In Progress` when work actually starts, run the pipeline to PR readiness. |
+| **Explicit ticket**   | "work on SCRUM-220"                                               | Retrieve it, `In Progress` when work starts, run the pipeline.                                                                          |
+
+Absent explicit authorization to fix, assume **find only**. "Find" is not "fix" — an audit that
+silently starts changing code has exceeded its mandate.
+
 ## 1. Establish the Jira issue — always first
 
 No implementation begins as an anonymous, untracked change.
@@ -161,7 +175,7 @@ Then stop. The human reviews and merges.
 
 ## Discovered-issue workflow
 
-When you find a new actionable problem mid-task:
+When you find a new actionable problem:
 
 1. Is it part of the active ticket? If yes, handle it in scope.
 2. If not — **do not scope-creep the current PR.** Search Jira first, with more than one
@@ -169,10 +183,38 @@ When you find a new actionable problem mid-task:
 3. Match found → reference it.
 4. No match → create an issue carrying the evidence you have: affected area, observed vs.
    expected behavior, impact, relevant paths, and the ticket you were on when you found it.
-5. Return to the original task.
+5. **Leave the new issue in `To Do`** (see the status rule below).
+6. Return to the original task.
 
 Do not file trivial observations, speculation, duplicates, or anything the active ticket
 already covers.
+
+### Status of a discovered ticket
+
+**A newly discovered ticket defaults to `To Do`.** It moves to `In Progress` only when **both**
+hold:
+
+1. the request authorizes working on the discovered problem ("find and fix", "resolve",
+   "implement", "work on"), **and**
+2. you actually begin work on that ticket.
+
+Never move it merely because it was discovered, was created, looks important, or is worth
+fixing later. **Creating a ticket is not starting work.** Status must describe reality, and a
+board full of `In Progress` tickets nobody is touching tells the team nothing.
+
+### Switching the active ticket
+
+Default: file it, leave it `To Do`, finish the ticket you are on.
+
+Only when the request explicitly authorized find-and-fix may a discovered ticket become the
+active work item — and then:
+
+- establish the Jira issue first
+- **state the scope change out loud**; never switch silently
+- keep it a separate PR unless the two problems are genuinely inseparable
+
+Prefer one issue to one coherent PR. Never quietly bundle unrelated fixes into one PR — a
+reviewer cannot approve half a diff.
 
 ## Blocked
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,8 +146,17 @@ it rather than filing a duplicate. If none exists and the problem is outside the
 current task's scope, create the issue. Filing it is authorized; you do not need
 to be asked.
 
+**A newly created discovered issue stays in `To Do`.** Filing is not starting.
+Move it to `In Progress` only when the request authorizes working on that problem
+(for example "find and fix", "resolve", "work on") **and** you actually begin work
+on it. Discovery, creation, or apparent importance are never sufficient on their
+own. User intent decides whether a request is find-only or find-and-fix; absent
+explicit authorization to fix, assume find-only.
+
 **Do not widen the current change or PR to fix an unrelated discovery.** Track it
-in Jira and stay on the active ticket.
+in Jira and stay on the active ticket. If a request did authorize fixing what you
+find, you may switch the active ticket — but state the scope change explicitly and
+keep it a separate PR unless the problems are genuinely inseparable.
 
 Give a new issue the evidence you have: affected area, observed vs. expected
 behavior, impact, relevant paths, and the ticket you were on when you found it.

--- a/docs/development/AI_DEVELOPMENT_WORKFLOW.md
+++ b/docs/development/AI_DEVELOPMENT_WORKFLOW.md
@@ -339,6 +339,27 @@ so is moving the ticket to `Done`.
 
 ## 11. Discovered-issue workflow
 
+### How you ask determines what happens
+
+Three usage modes. The difference matters, because it decides whether a discovered problem gets
+_filed_ or gets _fixed_:
+
+| You say                                                         | Claude does                                                                                                                                   | New tickets land in            |
+| --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| **"Find problems in X"** / "audit X for bugs"                   | Investigates, files or references issues, keeps auditing, reports findings. **Does not start fixing.**                                        | `To Do`                        |
+| **"Find problems in X and fix them"** / "resolve what you find" | Same discovery, then makes the issue active, moves it to `In Progress` when work actually starts, and runs the pipeline to a review-ready PR. | `In Progress` once work begins |
+| **"Work on SCRUM-220"**                                         | Retrieves that ticket and runs the normal pipeline.                                                                                           | n/a — existing ticket          |
+
+Absent explicit authorization to fix, Claude assumes **find only**. An audit that quietly starts
+rewriting code has exceeded its mandate, and you would be reviewing changes you never asked for.
+
+**A newly discovered ticket stays in `To Do`.** Filing is not starting. It moves to
+`In Progress` only when the request authorized fixing _and_ work actually begins — never merely
+because the problem was found, filed, or looks important. That way the board tells you what is
+genuinely underway rather than what was noticed.
+
+### The procedure
+
 You will find unrelated problems while working. Do not fix them in the current PR.
 
 ```
@@ -349,11 +370,15 @@ search Jira for a duplicate     ← always first
 exists? ──yes──► reference it, move on
    │ no
    ↓
-outside current scope? ──yes──► file an issue, return to the active ticket
+outside current scope? ──yes──► file an issue (To Do), return to the active ticket
    │ no
    ↓
 it's part of the active ticket → fix it
 ```
+
+If the request authorized find-and-fix, Claude may switch the active ticket to a discovered
+issue — but it states the scope change explicitly and keeps it a separate PR unless the two
+problems are genuinely inseparable. One issue, one coherent PR.
 
 Why: a PR fixing three unrelated things is hard to review, hard to revert, and hides its own
 risk. Widening scope mid-change is how small tickets become un-reviewable.


### PR DESCRIPTION
## Jira ticket

[SCRUM-218](https://carpoolnu.atlassian.net/browse/SCRUM-218) — Make the discovered-issue workflow intent-aware (find vs find-and-fix)

Follows [SCRUM-215](https://carpoolnu.atlassian.net/browse/SCRUM-215) (human documentation) and [SCRUM-217](https://carpoolnu.atlassian.net/browse/SCRUM-217) (Skill creation), both merged.

## Purpose

"Find problems in X" and "find problems in X **and fix them**" were treated identically. The Skill said to search, reference or file, and resume — but never said what *status* a newly filed ticket should carry, or when a discovered ticket may become the active work item.

That gap allowed two failure modes: starting work the user never authorized, or filing a ticket in a status implying work was underway when nothing had started.

## Behavior added

| You say | Claude does | New tickets land in |
|---|---|---|
| **"Find problems in X"** / "audit X for bugs" | Investigates, files or references issues, keeps auditing, reports findings. **Does not start fixing.** | `To Do` |
| **"Find problems in X and fix them"** / "resolve what you find" | Same discovery, then makes the issue active, moves it to `In Progress` when work actually starts, runs the pipeline to a review-ready PR. | `In Progress` once work begins |
| **"Work on SCRUM-220"** | Retrieves that ticket and runs the normal pipeline. | n/a — existing ticket |

Absent explicit authorization to fix, **assume find-only**. An audit that silently starts changing code has exceeded its mandate.

### Core rule

A newly discovered ticket **defaults to `To Do`**. It moves to `In Progress` only when **both** hold:

1. the request authorizes working on that problem ("find and fix", "resolve", "implement", "work on"), **and**
2. work on that ticket actually begins.

Discovery, creation, or apparent importance are never sufficient. **Creating a ticket is not starting work.**

### Scope control

Default: file it, leave it `To Do`, finish the current ticket. Where a request did authorize find-and-fix, the active ticket may switch — but only after the issue is established, with the scope change **stated out loud**, and as a separate PR unless the problems are genuinely inseparable. One issue, one coherent PR.

## Files changed

| File | Change |
|---|---|
| `.claude/skills/jira-ticket/SKILL.md` | +44/−2 — new step 0 mode table read before touching anything; discovered-issue section gains the `To Do` default, the two-condition status rule, and active-ticket switching rules |
| `CLAUDE.md` | +10/−1 — smallest clarification to Work tracking |
| `docs/development/AI_DEVELOPMENT_WORKFLOW.md` | +25/−2 — usage-mode table for humans |

## Preserved invariants

`Code Review` still requires a real pushed PR · `Done` remains human-only · no merging by any route · transitions resolve by status **name**, not hard-coded ID · `.claude/settings.json` and `.mcp.json` untouched, no permission weakening.

## Validation performed

- Prettier clean on all three files; Skill frontmatter parses (`name`, `description`)
- All Skill relative links, guide links, and internal anchors resolve
- Behavioral assertions verified in each file (find-only default, two-condition rule, creation-is-not-starting, explicit scope change, one-coherent-PR)
- Invariant spot-checks confirmed intact in each file's own wording
- Secret / credential / personal-path scan: clean
- `yarn lint` clean · `yarn tsc` clean · `yarn test --passWithNoTests` exits 0 with **zero test files present** (vacuous pass, not coverage)

## Known limitations / risks

- This is prose guidance, not mechanical enforcement. `.claude/settings.json` remains the only real guardrail; nothing here can stop a determined mistake.
- Intent classification is a judgment call on ambiguous phrasing ("look into X"). The rule biases toward find-only, which fails safe.
- No test suite exists, so `test.yml` remains a placeholder in practice.
- Branch protection on `main` is still unverified (no admin access to repository Settings).

## Related Jira issues

- **SCRUM-216** — `.claude/settings.local.json` missing from repository `.gitignore` (open, `To Do`, unrelated)
- **SCRUM-136** — covers the husky v10 and `next lint`/Next 16 deprecation warnings seen in local runs; referenced, not duplicated

No new issues were discovered during this work, and no discovered ticket was moved to `In Progress`.

## Scope confirmation

Documentation and workflow-procedure only. No application code, Prisma/schema, dependency, permissions, MCP, or CI workflow changes.

**The pre-existing unrelated `yarn.lock` modification is excluded** — blob hash captured before and after branching, unchanged, still unstaged in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)