### PR TITLE
SCRUM-216: gitignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,10 @@ yarn-error.log*
 
 # local DB
 nucarpool-db-data/
+
+# Claude Code
+# .claude/settings.json and .claude/skills/ are intentionally tracked — they are
+# the shared permission guardrails and workflow. Only per-machine overrides,
+# which Claude Code writes itself when you approve a permission permanently,
+# are personal. Never commit them.
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,10 @@ There are no test files yet. Jest uses the `ts-jest` preset with the default `no
 **Repo hygiene**
 
 - Do not modify `package.json`, `yarn.lock`, or dependencies during unrelated work.
+- Never stage or commit `.claude/settings.local.json`. It is gitignored and holds one
+  developer's machine-local permission overrides; committing it would change what Claude Code
+  is allowed to do for the whole team. `.claude/settings.json` is the shared file and stays
+  tracked.
 
 ## Architecture essentials
 

--- a/docs/development/AI_DEVELOPMENT_WORKFLOW.md
+++ b/docs/development/AI_DEVELOPMENT_WORKFLOW.md
@@ -67,7 +67,7 @@ Three ideas carry the design:
 | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------ |
 | [`CLAUDE.md`](../../CLAUDE.md)                                                     | Durable project instructions: commands, architecture gotchas, safety, git policy. Loaded every session. | yes    |
 | [`.claude/settings.json`](../../.claude/settings.json)                             | Permission model: allowed / prompted / forbidden tools. **Source of truth.**                            | yes    |
-| `.claude/settings.local.json`                                                      | Your machine-local overrides. Personal.                                                                 | no     |
+| `.claude/settings.local.json`                                                      | Your machine-local overrides. Personal, gitignored — never commit it.                                   | no     |
 | [`.claude/skills/jira-ticket/SKILL.md`](../../.claude/skills/jira-ticket/SKILL.md) | The repeatable procedure for executing a ticket — see [§10](#10-standard-engineering-lifecycle).        | yes    |
 | [`.mcp.json`](../../.mcp.json)                                                     | Declares the Atlassian MCP server. URL only — no credentials.                                           | yes    |
 | [`README.md`](../../README.md)                                                     | Human setup: stack, environment variables, commands.                                                    | yes    |
@@ -407,7 +407,10 @@ either gated behind you or off the table.
 - **`ask` is a real decision point.** A declined prompt means _don't_ — adjust, don't retry the
   same call another way.
 
-Personal overrides go in `.claude/settings.local.json`. Keep it out of git ([§17](#17-known-limitations-and-teamadmin-responsibilities)).
+Personal overrides go in `.claude/settings.local.json` — Claude Code writes it for you the
+first time you approve a permission permanently. It is gitignored, so you will not normally see
+it in `git status`. **Never commit it:** your machine's overrides would silently become
+everyone's.
 
 ## 13. Git safety
 
@@ -495,8 +498,6 @@ part of the job** — see [§10](#10-standard-engineering-lifecycle). Inspect wi
 **Open items a future developer may pick up:**
 
 - Confirm and document branch protection once someone has admin access.
-- `.claude/settings.local.json` is not in the repository `.gitignore` (tracked as SCRUM-216),
-  so it can show up as untracked in a fresh clone. Do not commit it.
 - There is no test suite yet, so `test.yml` is a placeholder in practice.
 
 Everything else in this document describes **current** behavior; only the items above are open


### PR DESCRIPTION
[SCRUM-216](https://carpoolnu.atlassian.net/browse/SCRUM-216)

## Purpose

Claude Code writes machine-local permission overrides to `.claude/settings.local.json`. That file was invisible to `git status` **only on the current developer's machine**, because it matched a user-level `~/.config/git/ignore` rule outside the repository. The repo's own `.gitignore` had no `.claude` entry, so a fresh clone would show the file as untracked and could commit it — publishing one developer's permission overrides as the whole team's guardrails.

## Changes

| File | Change |
| --- | --- |
| `.gitignore` | Add `.claude/settings.local.json` under a `# Claude Code` heading, with a comment stating that `.claude/settings.json` and `.claude/skills/` stay tracked |
| `CLAUDE.md` | Add a **Repo hygiene** rule: never stage or commit the file |
| `docs/development/AI_DEVELOPMENT_WORKFLOW.md` | §3 table row notes it is gitignored; §12 is now self-contained; the §17 open item tracking this gap is removed |

Two deliberate choices:

- **The pattern is `.claude/settings.local.json`, not `.claude/`.** It contains a slash so it anchors to the repo root, and it leaves the shared settings and the `jira-ticket` Skill tracked. Ignoring the directory would untrack both.
- **Documentation is part of the fix, not extra.** Ignoring a file makes it undiscoverable, and git has no mechanism to advertise a file's existence. Since Claude Code creates the file itself, what a developer needs to know is not *how to make one* but *that it is theirs and must not be committed*. `CLAUDE.md` is the surface that reaches Claude, which is what stages files.

`§12` previously deferred its "keep it out of git" explanation to the `§17` open item, so removing that bullet without rewriting `§12` would have left a dangling cross-reference.

## Validation

- `yarn lint` — clean
- `yarn tsc` — clean
- `npx prettier --check` on both markdown files — passes; husky `pretty-quick` passed on commit
- `git check-ignore -v` confirms the rule now resolves to `.gitignore:46` rather than the personal global file
- Re-verified with `GIT_CONFIG_GLOBAL=/dev/null` (simulating a clone without the personal global ignore): still ignored, which is the actual acceptance criterion
- Confirmed `.claude/settings.json` and `.claude/skills/jira-ticket/SKILL.md` are still unignored and still tracked
- No stale `SCRUM-216` references remain in the repo; the one surviving `§17` anchor link (from `§13`, about branch protection) still resolves
- Secrets scan over the diff — clean

`yarn test` not run: the change touches only ignore rules and documentation, and there is no test suite, so it would be a vacuous pass either way.

## Excluded from this PR

`yarn.lock` has a large pre-existing modification (285 insertions, 203 deletions) in the working tree that predates this work and is unrelated to it. It was deliberately left unstaged, per the rule against touching dependency manifests during unrelated work. It remains uncommitted in the working tree.

## Discovered during this work

`README.md` — the first file a new developer opens — never mentions Claude Code or links `docs/development/AI_DEVELOPMENT_WORKFLOW.md`, so that 507-line doc is only reachable if you already know it exists. That weakens documentation as a propagation channel generally, not just for this ticket. Filed separately rather than widened into this PR. Adjacent but non-overlapping: SCRUM-205 (In Progress) also edits `README.md`, for environment variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)