### PR TITLE
SCRUM-219: index the project's documentation from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,14 @@ NEXT_PUBLIC_ENV="<environment-name>"
 | `yarn db:start` / `yarn db:stop` | Start / stop the local MySQL container            |
 | `yarn db:schema`                 | Apply migrations and regenerate the Prisma client |
 | `yarn seed`                      | Populate the database with generated users        |
+
+## Documentation
+
+This project is developed with Claude Code following a Jira-first workflow. Read the workflow guide before your first contribution — it covers conventions this README does not. The layer docs are worth reading before you edit the layer they describe.
+
+| Document                                                                        | Covers                                                                                                                                                                                                                |
+| ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Claude Code development workflow](docs/development/AI_DEVELOPMENT_WORKFLOW.md) | Claude Code and Atlassian MCP setup, the Jira-first ticket lifecycle, the allow/ask/deny permission model, git and branch safety, CI behavior, and troubleshooting                                                    |
+| [`CLAUDE.md`](CLAUDE.md)                                                        | The instructions Claude Code loads every session: commands, safety boundaries, architecture and data-model gotchas, and git policy. Useful even if you never run Claude Code — it documents the project, not the tool |
+| [tRPC routers](src/server/router/README.md)                                     | Routers, per-request context, auth middleware, and how to write a procedure — read before adding or changing an endpoint                                                                                              |
+| [Database layer](src/server/db/README.md)                                       | The Prisma client, schema conventions, and the migration workflow — read before touching `prisma/schema.prisma`                                                                                                       |


### PR DESCRIPTION
[SCRUM-219](https://carpoolnu.atlassian.net/browse/SCRUM-219)

## Purpose

`README.md` is the entry point a new developer actually opens, and it linked nothing under `docs/` or `src/server/`. `docs/development/AI_DEVELOPMENT_WORKFLOW.md` — 500+ lines covering Claude Code setup, Atlassian MCP auth, the Jira-first lifecycle, the permission model, git safety, CI, and troubleshooting — was reachable only by someone who already knew it existed.

That matters more than convenience in this repo. Much of the safety model is written convention plus client-side configuration rather than server-enforced tooling, so documentation *is* the propagation channel for team rules. An unlinked document propagates to nobody.

## Changes

One file, purely additive: a `## Documentation` section in `README.md` indexing four documents, each with a one-line description of what it covers and when to read it.

| Indexed | Why it's there |
| --- | --- |
| `docs/development/AI_DEVELOPMENT_WORKFLOW.md` | The unlinked document this ticket is about |
| `CLAUDE.md` | The ticket's "Observed" notes README never mentions it either |
| `src/server/router/README.md` | Referenced by `CLAUDE.md` but not by `README.md` |
| `src/server/db/README.md` | Same |

Descriptions only — no content duplicated from the linked documents, so nothing new has to be kept in sync. Descriptions were written against each file's actual section headings rather than assumed.

## Placement

Deliberately at the end of the file. **SCRUM-205 is `In Progress` and reworks `README.md`'s Environment Variables block and the `.env.example` line at line 29.** Appending after `Useful Commands` keeps this diff entirely clear of that region, so the two tickets should merge in either order without conflict. Verified: the diff touches no line containing `.env.example` or any environment variable name.

A `## Documentation` heading also appears in GitHub's auto-generated README outline, so it is reachable without scrolling.

## Validation

- `yarn lint` — clean
- `yarn tsc` — clean
- `npx prettier --check README.md` — passes; husky `pretty-quick` passed on commit. README was prettier-clean beforehand, so normalization touched only the added table
- **Every relative link in the whole README resolves** — scripted check over all four new targets plus `prisma/schema.prisma`, which the new text mentions; no broken links
- Secrets scan over the diff — clean, no real values
- Confirmed the diff overlaps none of SCRUM-205's region

`yarn test` not run: documentation-only change, and there is no test suite, so it would be a vacuous pass either way.

## Acceptance criteria

The ticket's suggested fix was a short documentation-index section pointing at the workflow doc and the two layer READMEs, with one-line descriptions and no duplicated content. All met, plus `CLAUDE.md` per the ticket's own observation.

## Excluded from this PR

`yarn.lock` has a large pre-existing working-tree modification (+285/-203) that predates this work and is unrelated. Left unstaged per the rule against touching dependency manifests during unrelated work; it remains uncommitted locally.

## Related

Follows SCRUM-216 (PR #46, merged), during which this gap was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)