### PR TITLE
Soften the Documentation section's opening line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ NEXT_PUBLIC_ENV="<environment-name>"
 
 ## Documentation
 
-This project is developed with Claude Code following a Jira-first workflow. Read the workflow guide before your first contribution — it covers conventions this README does not. The layer docs are worth reading before you edit the layer they describe.
+This project is developed with a Jira workflow. Read the workflow guide before your first contribution — it covers conventions this README does not. The layer docs are worth reading before you edit the layer they describe.
 
 | Document                                                                        | Covers                                                                                                                                                                                                                |
 | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Purpose

A one-sentence wording change to the `## Documentation` section added in [SCRUM-219](https://carpoolnu.atlassian.net/browse/SCRUM-219) (PR #47, merged). Describes the process as "a Jira workflow" rather than naming Claude Code and calling it "Jira-first".

```diff
-This project is developed with Claude Code following a Jira-first workflow. Read the workflow guide...
+This project is developed with a Jira workflow. Read the workflow guide...
```

The linked documents and their descriptions are unchanged, so the section still points at the workflow guide, `CLAUDE.md`, and the two layer READMEs.

## Tracking

No Jira issue — a one-line wording tweak falls under the "don't manufacture bureaucracy" exception for trivial changes. Raise one if you'd rather have it tracked.

## Validation

- `npx prettier --check README.md` — passes; husky `pretty-quick` passed on commit
- `yarn lint` — clean
- No link, path, or table-structure changes, so nothing to re-resolve

`yarn tsc` and `yarn test` not run: a single prose line in a markdown file, and there is no test suite. CI will run all three regardless.

## Excluded from this PR

`yarn.lock` has a large pre-existing working-tree modification (+285/-203), unrelated to this change and predating it. Left unstaged; it remains uncommitted locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)