### PR TITLE
SCRUM-205: add .env.example and make it the single source for env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,93 @@
+# NUCarpool environment variables
+#
+# Copy this file and fill in real values:
+#
+#   cp .env.example .env
+#
+# Ask a maintainer for development credentials. Never commit .env — it is
+# gitignored, and this file must only ever contain placeholders.
+#
+# PUBLIC vs SECRET: variables prefixed NEXT_PUBLIC_ are inlined into the client
+# bundle at build time and are visible to anyone using the site. Everything else
+# is server-only and must be treated as a secret.
+#
+# Unless a comment says otherwise, every variable here is REQUIRED. envsafe
+# validates them at import time — see src/utils/env/browser.ts and
+# src/utils/env/server.ts — so the app will not start if one is missing.
+
+
+# -----------------------------------------------------------------------------
+# Local database — Docker Compose
+# -----------------------------------------------------------------------------
+# The MYSQL_* variables are read only by docker-compose.yml, to provision the
+# container. The app itself reads DATABASE_URL, so the user, password, port, and
+# database name inside DATABASE_URL must match the container's. The values below
+# are already consistent with each other and work as-is for local development.
+MYSQL_PORT="3306"
+MYSQL_ROOT_PASSWORD="local-dev-password"
+MYSQL_DATABASE="nucarpool"
+DATABASE_URL="mysql://root:local-dev-password@localhost:3306/nucarpool"
+
+
+# -----------------------------------------------------------------------------
+# NextAuth
+# -----------------------------------------------------------------------------
+# NEXTAUTH_SECRET has a development default, so it is optional locally, but set
+# it anyway. NEXTAUTH_URL is read by NextAuth itself rather than through envsafe.
+NEXTAUTH_SECRET="replace-with-a-long-random-string"
+NEXTAUTH_URL="http://localhost:3000"
+
+# Azure AD — Northeastern SSO. The only sign-in method outside staging.
+AZURE_CLIENT_ID="00000000-0000-0000-0000-000000000000"
+AZURE_CLIENT_SECRET="replace-with-azure-client-secret"
+AZURE_TENANT_ID="00000000-0000-0000-0000-000000000000"
+
+# Google. The sign-in button only appears when NEXT_PUBLIC_ENV=staging, but
+# these are validated at startup in every environment, so they must be present.
+GOOGLE_CLIENT_ID="replace-with-google-client-id"
+GOOGLE_CLIENT_SECRET="replace-with-google-client-secret"
+
+
+# -----------------------------------------------------------------------------
+# AWS — SES for email, S3 for profile pictures
+# -----------------------------------------------------------------------------
+# Note the suffixed names. The standard AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+# / AWS_REGION names fail validation.
+ACCESS_KEY_ID_AWS="replace-with-aws-access-key-id"
+SECRET_ACCESS_KEY_AWS="replace-with-aws-secret-access-key"
+REGION_AWS="us-east-1"
+
+
+# -----------------------------------------------------------------------------
+# Mapbox — map, geocoding, routing
+# -----------------------------------------------------------------------------
+# PUBLIC. Scope this token to the minimum required and restrict it by URL.
+NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN="pk.replace-with-mapbox-public-token"
+
+
+# -----------------------------------------------------------------------------
+# Pusher — real-time messaging
+# -----------------------------------------------------------------------------
+# The NEXT_PUBLIC_ pair is PUBLIC; the app ID and secret are server-only.
+NEXT_PUBLIC_PUSHER_KEY="replace-with-pusher-key"
+NEXT_PUBLIC_PUSHER_CLUSTER="us2"
+PUSHER_APP_ID="replace-with-pusher-app-id"
+PUSHER_SECRET="replace-with-pusher-secret"
+
+
+# -----------------------------------------------------------------------------
+# Mixpanel — analytics
+# -----------------------------------------------------------------------------
+# PUBLIC. Any non-empty value works locally.
+NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN="replace-with-mixpanel-token"
+
+
+# -----------------------------------------------------------------------------
+# Environment name — OPTIONAL, PUBLIC
+# -----------------------------------------------------------------------------
+# Not validated by envsafe. Leave it unset for normal local development.
+# Setting it to "staging" enables the Google sign-in button, namespaces S3
+# profile-picture keys as profile-pictures/{env}/{userId}, and restricts SES
+# recipients to @gmail.com addresses. Changing the value orphans existing
+# uploads, because the S3 key prefix changes with it.
+NEXT_PUBLIC_ENV=""

--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ cd nucarpool
 yarn install
 ```
 
-Create a `.env` in the repository root containing the variables below. There is no `.env.example` — ask a maintainer for development credentials. The app validates these at startup and will not boot if one is missing.
+Create a `.env` in the repository root by copying the example file, then fill in real values:
+
+```bash
+cp .env.example .env
+```
+
+Ask a maintainer for development credentials. The app validates these at startup and will not boot if one is missing.
 
 Then start the database, set up the schema, and run the app:
 
@@ -41,45 +47,16 @@ The app runs at <http://localhost:3000>. `yarn startup` runs `yarn db:start` and
 
 ## Environment Variables
 
-Placeholders only — never commit real values. `.env` is gitignored.
+[`.env.example`](.env.example) is the authoritative list. It documents every variable, grouped by service, with placeholder values and notes on which are optional. Copy it to `.env` and fill in real values — never commit them, and keep placeholders only in `.env.example` itself. `.env` is gitignored.
 
-```env
-# Database — MYSQL_* are read by docker-compose; the app itself only uses DATABASE_URL,
-# so its user, password, port, and database name must match the container.
-DATABASE_URL="mysql://<user>:<password>@localhost:<MYSQL_PORT>/<MYSQL_DATABASE>"
-MYSQL_PORT="<host-port>"
-MYSQL_ROOT_PASSWORD="<local-only-password>"
-MYSQL_DATABASE="<database-name>"
+Four things that commonly trip people up:
 
-# Authentication
-NEXTAUTH_SECRET="<random-secret>"
-NEXTAUTH_URL="http://localhost:3000"
-AZURE_CLIENT_ID="<azure-client-id>"
-AZURE_CLIENT_SECRET="<azure-client-secret>"
-AZURE_TENANT_ID="<azure-tenant-id>"
-GOOGLE_CLIENT_ID="<google-client-id>"
-GOOGLE_CLIENT_SECRET="<google-client-secret>"
+- **AWS keys use suffixed names** — `ACCESS_KEY_ID_AWS`, `SECRET_ACCESS_KEY_AWS`, `REGION_AWS`. The standard `AWS_*` names fail validation.
+- **`MYSQL_*` are read only by Docker Compose**, to provision the container. The app reads `DATABASE_URL`, so the user, password, port, and database name inside it must match the container's.
+- **`NEXT_PUBLIC_*` variables are inlined into the client bundle** at build time and are therefore public. Everything else is server-only.
+- **`GOOGLE_*` are required even locally.** The Google sign-in button only appears when `NEXT_PUBLIC_ENV=staging`, but the variables are validated in every environment.
 
-# AWS (SES + S3) — note the suffixed names; standard AWS_* names will fail validation
-ACCESS_KEY_ID_AWS="<aws-access-key-id>"
-SECRET_ACCESS_KEY_AWS="<aws-secret-access-key>"
-REGION_AWS="<aws-region>"
-
-# Mapbox
-NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN="<mapbox-public-token>"
-
-# Pusher
-NEXT_PUBLIC_PUSHER_KEY="<pusher-key>"
-NEXT_PUBLIC_PUSHER_CLUSTER="<pusher-cluster>"
-PUSHER_APP_ID="<pusher-app-id>"
-PUSHER_SECRET="<pusher-secret>"
-
-# Mixpanel — any non-empty value works locally
-NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN="<mixpanel-token>"
-
-# Optional — "staging" enables Google sign-in and namespaces S3 uploads
-NEXT_PUBLIC_ENV="<environment-name>"
-```
+Validation runs at import time in [`src/utils/env/browser.ts`](src/utils/env/browser.ts) and [`src/utils/env/server.ts`](src/utils/env/server.ts), which is why a missing variable stops the app from starting rather than failing later.
 
 ## Useful Commands
 


### PR DESCRIPTION
[SCRUM-205](https://carpoolnu.atlassian.net/browse/SCRUM-205)

## Purpose

There was no file to copy when setting up a local environment — a new developer had to hand-assemble `.env` from a list embedded in `README.md`, with no indication of which variables are public, which are optional, or why some of the names look wrong.

## Changes

**New `.env.example`** — all 21 variables, grouped by service, placeholders only.

The variable set was derived **from the code, not from the README**:

| Source | Variables |
| --- | --- |
| `src/utils/env/server.ts` (envsafe) | `DATABASE_URL`, `NEXTAUTH_SECRET`, `ACCESS_KEY_ID_AWS`, `SECRET_ACCESS_KEY_AWS`, `REGION_AWS`, `AZURE_*`, `GOOGLE_*`, `PUSHER_APP_ID`, `PUSHER_SECRET` |
| `src/utils/env/browser.ts` (envsafe) | `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN`, `NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN`, `NEXT_PUBLIC_PUSHER_KEY`, `NEXT_PUBLIC_PUSHER_CLUSTER` |
| `docker-compose.yml` substitutions | `MYSQL_PORT`, `MYSQL_ROOT_PASSWORD`, `MYSQL_DATABASE` |
| Read by NextAuth directly, not via envsafe | `NEXTAUTH_URL` |
| Read via `process.env`, not validated | `NEXT_PUBLIC_ENV` |

**`README.md`** — `cp .env.example .env` in Getting Started, and the duplicated variable list replaced by a pointer to `.env.example` plus the four gotchas worth stating up front.

## Things the file documents that the old list did not

- `NEXT_PUBLIC_*` are inlined into the client bundle at build time and are therefore **public**; everything else is server-only
- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` are validated in **every** environment, even though the Google button only appears when `NEXT_PUBLIC_ENV=staging` — a non-obvious startup failure
- `NEXTAUTH_SECRET` has a development default, so it is optional locally
- `NEXT_PUBLIC_ENV` is optional, and changing it **orphans existing S3 uploads**, since it namespaces the profile-picture key prefix
- The database placeholders are internally consistent, so `DATABASE_URL` matches the container the `MYSQL_*` values provision

Values deliberately carry **no inline comments**. Docker Compose's dotenv parsing does not handle trailing `# comment` reliably, and Compose consumes this file's `MYSQL_*` variables — so annotations sit on their own lines above each group.

## Validation

- **Scripted set comparison**: variables declared in `.env.example` vs. those the code requires — exact match both directions, nothing missing and nothing invented
- **Syntax + consistency check**: parsed with a dotenv-grammar parser — 21 keys, no syntax errors, no unbalanced quotes; asserted `DATABASE_URL`'s port, password, and database name equal the `MYSQL_*` values
- **Secrets**: no credential-shaped values (`AKIA`/`ASIA`/`sk-`/`ghp_`/`xox`/JWT prefixes); only `NEXT_PUBLIC_ENV` is intentionally empty. `.env` itself was never read — it is a denied path, and everything here came from source
- Confirmed `.env.example` is **not** matched by `.gitignore`, and `.env` still is
- `yarn lint`, `yarn tsc` — clean; `npx prettier --check README.md` passes; husky `pretty-quick` passed on commit
- Every relative link in README resolves, including the two new `src/utils/env/*.ts` links

`yarn test` not run: no test suite exists, so it would be a vacuous pass. Note that neither this nor CI actually boots the app against `.env.example`; correctness rests on the static comparison above.

## One correction to the ticket's premise

The ticket states README's list "does not include all variables required by the application and Docker Compose." **That is no longer true** — I compared it against the code, and the existing README list was already complete and correct at all 21 variables. It appears to have been fixed after the ticket was filed.

The rest of the ticket stands: there was still no `.env.example`, and the list was duplicated in prose where it could drift. This PR delivers the file and removes the duplication, so the premise being stale doesn't change the work.

## Acceptance criteria

| Criterion | Status |
| --- | --- |
| Add `.env.example` with names and fake placeholders only | done |
| Include local docker variables | done — `MYSQL_PORT`, `MYSQL_ROOT_PASSWORD`, `MYSQL_DATABASE` |
| Include pusher variables | done — all four |
| Group variables by service | done |
| Document which variables are public | done — stated as a rule and marked per group |
| README instructs `cp .env.example .env` | done |
| Remove or replace the duplicated list in README | done — replaced with a pointer |
| No real secret values | verified, see above |

## Excluded from this PR

`yarn.lock` has a large pre-existing working-tree modification (+285/-203), unrelated and predating this work. Left unstaged; still uncommitted locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)