### PR TITLE
SCRUM-181: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,106 @@
+# Dependabot configuration (SCRUM-181).
+# Reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+#
+# Version updates begin automatically once this file is on the default branch.
+# Vulnerability-driven security updates additionally require "Dependabot alerts"
+# and "Dependabot security updates" to be turned on under
+# Settings -> Code security. Those toggles are repository settings and cannot be
+# enabled from this file.
+version: 2
+
+updates:
+  # ---------------------------------------------------------------------------
+  # npm ecosystem — package.json and yarn.lock at the repository root.
+  # Yarn Classic is the package manager; the "npm" ecosystem covers it.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    # Let a release age on the registry before adopting it, so publishes that
+    # are yanked or found to be compromised have time to be withdrawn.
+    cooldown:
+      default-days: 7
+    groups:
+      # These packages are coupled and have to move together — bumping one
+      # without its siblings breaks the build, so these groups deliberately
+      # include major versions as well.
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+      prisma:
+        patterns:
+          - "prisma"
+          - "@prisma/client"
+      trpc:
+        patterns:
+          - "@trpc/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      mui:
+        patterns:
+          - "@mui/*"
+          - "@emotion/*"
+      antd:
+        patterns:
+          - "antd"
+          - "rc-*"
+      chart:
+        patterns:
+          - "chart.js"
+          - "chartjs-*"
+          - "react-chartjs-2"
+
+      # Everything else: minor and patch updates batch into two pull requests.
+      # Majors are left out of these groups on purpose, so each one arrives as
+      # its own pull request that can be reviewed and tested individually.
+      production-minor-and-patch:
+        dependency-type: "production"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      development-minor-and-patch:
+        dependency-type: "development"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---------------------------------------------------------------------------
+  # GitHub Actions used by the workflows in .github/workflows.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    cooldown:
+      default-days: 7
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/docs/development/AI_DEVELOPMENT_WORKFLOW.md
+++ b/docs/development/AI_DEVELOPMENT_WORKFLOW.md
@@ -72,6 +72,7 @@ Three ideas carry the design:
 | [`.mcp.json`](../../.mcp.json)                                                     | Declares the Atlassian MCP server. URL only — no credentials.                                           | yes    |
 | [`README.md`](../../README.md)                                                     | Human setup: stack, environment variables, commands.                                                    | yes    |
 | [`.github/workflows/`](../../.github/workflows/)                                   | CI — see [§14](#14-ci-behavior).                                                                        | yes    |
+| [`.github/dependabot.yml`](../../.github/dependabot.yml)                           | Dependency update automation — see [§14](#14-ci-behavior).                                              | yes    |
 
 Layer-specific docs: [`src/server/router/README.md`](../../src/server/router/README.md)
 (tRPC routers, context, auth) and [`src/server/db/README.md`](../../src/server/db/README.md)
@@ -451,6 +452,27 @@ Because lint and type-check fire on different triggers, **checking CI after the 
 part of the job** — see [§10](#10-standard-engineering-lifecycle). Inspect with
 `gh pr checks` and `gh run view`; both are read-only and need no approval.
 
+### Dependency updates
+
+[`.github/dependabot.yml`](../../.github/dependabot.yml) configures Dependabot for the `npm`
+ecosystem (`package.json` and `yarn.lock`) and for the actions pinned in
+[`.github/workflows/`](../../.github/workflows/). Both run weekly, Monday morning Eastern.
+
+- Packages that have to move together are **grouped** into one pull request: `@aws-sdk/*`,
+  `prisma` with `@prisma/client`, `@trpc/*`, `react` with `react-dom` and their types,
+  `@mui/*` with `@emotion/*`, `antd` with `rc-*`, and the Chart.js set. Bumping any of these
+  in isolation breaks the build, so those groups include majors.
+- Everything else batches by risk: minor and patch updates arrive as one production and one
+  development pull request, while **majors arrive individually** so each can be reviewed and
+  tested on its own.
+- A 7-day cooldown holds brand-new releases back, giving a yanked or compromised publish time
+  to be withdrawn before it reaches a pull request.
+- Dependabot pull requests run the same CI as everything else. Their `GITHUB_TOKEN` is
+  read-only and they cannot read repository secrets — fine here, since no current workflow
+  needs one.
+- **Version updates begin as soon as the config is on `main`. Security updates do not** — see
+  [§17](#17-known-limitations-and-teamadmin-responsibilities).
+
 ## 15. Security considerations
 
 - **Secrets.** Never print, echo, or copy `.env` values into output, code, or commits.
@@ -494,6 +516,10 @@ part of the job** — see [§10](#10-standard-engineering-lifecycle). Inspect wi
   treat the repository-side rules above as the protection you can actually rely on.
 - Whether CI checks are _required_ before merge; who can merge; whether review is mandatory.
 - PlanetScale deploy-request permissions.
+- **Dependabot alerts and security updates.** [`.github/dependabot.yml`](../../.github/dependabot.yml)
+  turns on scheduled _version_ updates by itself, but the vulnerability-driven _security_
+  updates are a repository setting, under Settings → Code security. Until an admin enables
+  them, the repository gets routine scheduled upgrades and no alert-triggered patches.
 
 **Open items a future developer may pick up:**
 


### PR DESCRIPTION
## Purpose

[SCRUM-181](https://carpoolnu.atlassian.net/browse/SCRUM-181) — the repository has no automated dependency maintenance, so upgrades and vulnerability patches depend on someone noticing them by hand.

Adds `.github/dependabot.yml` and documents it.

## What changed

**`.github/dependabot.yml`** — two ecosystems, both weekly (Monday 06:00 America/New_York):

| Ecosystem | Covers | PR limit |
| --- | --- | --- |
| `npm` | `package.json` + `yarn.lock` | 10 |
| `github-actions` | `.github/workflows/` | 5 |

Grouping is the substance of the config. Ungrouped, ~90 direct dependencies would each open their own PR, and packages that must move in lockstep would arrive in separate PRs that individually break the build.

- **Coupled families ship as one PR, majors included** — `@aws-sdk/*`, `prisma` + `@prisma/client`, `@trpc/*`, `react` + `react-dom` + their `@types`, `@mui/*` + `@emotion/*`, `antd` + `rc-*`, and the Chart.js set. Splitting any of these breaks the build, so grouping majors here is deliberate.
- **Everything else batches by risk** — minor and patch collapse into one production and one development PR; **majors stay individual** so each gets its own review and test.
- **7-day cooldown** so a yanked or compromised publish has time to be withdrawn before it reaches a PR.

**`docs/development/AI_DEVELOPMENT_WORKFLOW.md`** — registers the file in the §3 config table, adds a "Dependency updates" subsection to §14, and records the admin gap below in §17.

## Validation

- Config validates against the official [SchemaStore `dependabot-2.0`](https://json.schemastore.org/dependabot-2.0.json) schema (parsed with `js-yaml`, checked with `ajv`) — valid, no errors.
- Group matching simulated against the real dependency list, applying Dependabot's first-match-wins rule: minor/patch resolves to **9 PRs** instead of ~90; majors resolve to 7 grouped PRs plus individual PRs for the rest.
- `yarn lint` ✅ · `yarn tsc` ✅ · `npx prettier --check` ✅ on both files.
- No test run is meaningful here — the repo has no test files, so `yarn test` passes vacuously.

## Known limitations and risks

- **Security updates are not enabled by this PR.** The config turns on scheduled *version* updates once merged, but the vulnerability-driven *security* updates SCRUM-181 also describes are a repository setting under **Settings → Code security**. An admin has to enable "Dependabot alerts" and "Dependabot security updates" — this is documented in §17 as an admin responsibility. The ticket is not fully satisfied until someone does that.
- **The first run will be a large batch.** Dependencies are well behind, so expect the npm limit of 10 to fill immediately. Grouped minor/patch PRs compete with individual major PRs for those slots, so triaging the majors early is what lets the batched PRs through.
- Group precedence relies on Dependabot's documented "first group that it matches" rule, so the specific groups are ordered ahead of the two catch-alls. Reordering them would change behavior.
- Dependabot PRs run with a read-only `GITHUB_TOKEN` and no access to repository secrets. Fine for the current workflows, none of which need one.

## Deliberately excluded

- `yarn.lock` has pre-existing uncommitted modifications in the working tree that are **not mine** and are not part of this commit. Left untouched.
- Docker (`docker-compose.yml`) is not configured as an ecosystem — `mysql:5.7` is pinned to match PlanetScale, and auto-bumping it would break local/production parity for a dev-only container.

## Related issues found

- **[SCRUM-259](https://carpoolnu.atlassian.net/browse/SCRUM-259)** — filed during this work. Both `package-lock.json` and `yarn.lock` are committed, so Dependabot will maintain both and every dependency PR will carry a `package-lock.json` diff nothing reads. Out of scope here; deliberately not fixed in this PR.
- **[SCRUM-248](https://carpoolnu.atlassian.net/browse/SCRUM-248)** — already open. The `github-actions` ecosystem here directly serves its acceptance criterion about deprecated `actions/checkout` and `actions/setup-node` versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)