### PR TITLE
SCRUM-206: fix invalid Tailwind spacing class in GroupPage

### DIFF
--- a/src/components/GroupPage.tsx
+++ b/src/components/GroupPage.tsx
@@ -957,7 +957,7 @@ const GroupInfo = ({
             details={groupDetails}
             setDetails={setGroupDetails}
           />
-          <div className="flex justify-center mt2">
+          <div className="mt-2 flex justify-center">
             <button
               className="w-[150px] rounded-md bg-red-700 py-2 text-white hover:bg-red-800 transition-colors"
               onClick={async () => {


### PR DESCRIPTION
## Purpose

[SCRUM-206](https://carpoolnu.atlassian.net/browse/SCRUM-206) — replace the invalid Tailwind spacing utility in `GroupPage` and verify the layout.

## The bug

In `GroupInfo`, the wrapper around the driver-facing **Submit** button used `mt2`:

```jsx
<div className="flex justify-center mt2">
```

`mt2` is missing the hyphen, so it matches no Tailwind utility and no CSS rule is generated for it. The class was silently dead: the button rendered flush against `GroupDetailsForm` instead of receiving the intended top margin. Nothing errors on a nonexistent Tailwind class, which is why this survived.

## Change

One line in [`src/components/GroupPage.tsx:960`](src/components/GroupPage.tsx#L960):

```diff
-<div className="flex justify-center mt2">
+<div className="mt-2 flex justify-center">
```

`mt-2` (`margin-top: 0.5rem`) is the literal intent of the typo. It is also placed first in the class list to match the margin-first ordering the sibling containers in this component already use (`mt-4 flex flex-col`, `mt-4 pb-4 flex-shrink-0`).

## Validation

- `yarn lint` — clean, no warnings or errors
- `yarn tsc` — clean
- `yarn test --passWithNoTests` — no tests exist in the repo, so this is a vacuous pass, **not** coverage
- `npx prettier --check` on the file — passes; pre-commit `pretty-quick` hook passed
- **Tailwind compiled against the project config**: `.mt2` produces **0** rules, `.mt-2` resolves to `margin-top: 0.5rem`. This confirms both that the old class was dead and that the new one is live.
- **Audited all 137 class tokens** in `GroupPage.tsx` (static and template-literal `className`s) against compiled Tailwind output: `mt2` was the only dead class in the file.

Visual in-browser confirmation was not performed — that path requires an authenticated Azure AD session and a user in a group with the `DRIVER` role. The CSS-level verification above establishes the fix directly.

## Notes for the reviewer

- If the team would rather this button match the `mt-4` rhythm of the two sections below it, that is a one-character change — `mt-2` was chosen as the faithful reading of the original typo.
- **Pre-existing local changes deliberately excluded:** the working tree held uncommitted edits to `.github/dependabot.yml` and `yarn.lock` (leftovers from the already-merged SCRUM-181 work). Only `src/components/GroupPage.tsx` was staged; those files are untouched by this PR.
- Not filed as tickets, but worth flagging: `prettier-plugin-tailwindcss` is a declared devDependency but there is no Prettier config registering it, so under Prettier 3 it never loads and class ordering is not enforced anywhere in the repo. That is why an unsorted, malformed class list went unnoticed. Happy to file this separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)