### PR TITLE
SCRUM-261: replace `next lint` with a direct ESLint CLI invocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint --max-warnings=0",
+    "lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings=0",
     "check:env": "node scripts/check-env-contract.js",
     "db:start": "docker-compose -f docker-compose.yml up -d",
     "db:stop": "docker-compose -f docker-compose.yml down",


### PR DESCRIPTION
## Purpose

[SCRUM-261](https://carpoolnu.atlassian.net/browse/SCRUM-261) — `next lint` is deprecated and **removed in Next.js 16**. It printed a deprecation notice on every CI run and is a hard blocker on that upgrade.

## The change

One line in `package.json`:

```diff
-"lint": "next lint --max-warnings=0",
+"lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings=0",
```

No other file changes. `.eslintrc.json` is untouched, `.github/workflows/lint.yml` needs no change because it already just runs `yarn lint`, and **no dependency versions move**.

## Why a quoted glob instead of `--ext`

The obvious form is `eslint src --ext .ts,.tsx`, but **ESLint 9 removed `--ext`**. The glob works under both ESLint 8 (installed today) and ESLint 9, so when SCRUM-136 eventually upgrades `eslint-config-next` this line won't need revisiting. The quotes keep the pattern away from the shell so ESLint does the expansion — verified it survives yarn's `sh -c` intact.

I migrated by hand rather than running `npx @next/codemod@canary next-lint-to-eslint-cli .`, because that codemod targets a flat-config/ESLint 9 setup and would have dragged the dependency upgrade into this PR.

## Coverage is provably unchanged

`next lint` lints `app`, `pages`, `components`, `lib`, `src` — of those **only `src` exists** here. And `src` contains only TypeScript: **68 `.tsx` + 50 `.ts`**, with zero `.js`/`.jsx`/`.mjs`/`.cjs`.

Counted what each invocation actually processes, via `--format json`:

| invocation | files | by extension | errors | warnings |
|---|---|---|---|---|
| before (`next lint`) | 118 | — | 0 | 0 |
| after (`yarn lint`) | **118** | `{tsx: 68, ts: 50}` | 0 | 0 |

## Behavioural equivalence, not just a green run

A clean tree passing under both commands proves little, so I planted a `react-hooks/exhaustive-deps` violation in **both** a `.tsx` file and a `.ts` file (a custom hook, to confirm non-JSX files are still linted) and compared:

| | old `next lint` | new `yarn lint` |
|---|---|---|
| files reported | `Probe.tsx`, `useProbe.ts` | `Probe.tsx`, `useProbe.ts` |
| rule / line | `exhaustive-deps` @ 7:6 | `exhaustive-deps` @ 7:6 |
| exit code | **1** | **1** |
| clean tree exit | 0 | 0 |

Same files, same rule, same line, same gating. `--max-warnings=0` is preserved, so warnings still fail CI — which matters because `exhaustive-deps` is a *warning*, not an error.

The probes were removed; `git status` is clean apart from the one-line `package.json` change.

## Validation

In a clean worktree, no `.env` present:

- `yarn install --frozen-lockfile` — succeeds, lockfile unmodified
- `yarn lint` — clean, exit 0, and **0 occurrences of "deprecated"** in the output (was printed on every run before)
- `yarn lint` with a planted warning — exit 1
- `yarn tsc` — clean
- `yarn test --passWithNoTests` — passes **vacuously**; the repo still has no test files, so this is not coverage (SCRUM-211)
- `node scripts/check-env-contract.js` — passes
- `yarn prisma generate` + `yarn build` — build succeeds
- `prettier --check package.json` — clean; pre-commit hook passed

Incidentally `yarn lint` got a bit faster (~2.6s vs ~3.7s) by skipping Next's wrapper.

## Acceptance criteria

| AC | Status |
|---|---|
| Decide on `eslint-config-next` alignment vs SCRUM-136 | **Decided: leave to SCRUM-136.** No dependency versions touched here, so the two cannot conflict. |
| Replace `next lint` with ESLint CLI, preserving `--max-warnings=0` | Done |
| Linted paths still match today's coverage | Done — 118 files, verified by count and extension |
| If `eslint-config-next` moves to 15.x, expect ESLint 9 / flat config | **Not applicable** — this PR does not move it. Left on the ticket for SCRUM-136. |
| `lint.yml` continues to fail on warnings | Done — verified exit 1 on a planted warning |

## Known limitations

- **Root-level JS is still unlinted.** `next.config.js`, `tailwind.config.js`, `jest.config.js` and `scripts/check-env-contract.js` were never covered by `next lint` either, so this PR deliberately preserves that gap rather than expanding scope. Widening the glob is a reasonable follow-up but would likely surface new findings and belongs in its own change.
- `eslint-config-next` remains 3 majors behind `next`. Verified previously that it still works — 51 rules resolve and the hook rules are active — but the ESLint 9 / flat-config migration is still ahead, under SCRUM-136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)