### PR TITLE
SCRUM-262: correct the CI description in CLAUDE.md and the workflow guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,13 +16,14 @@ yarn startup      # yarn db:start && next dev
 yarn build        # production build
 yarn lint         # eslint
 yarn tsc          # type check (no npm script; resolves node_modules/.bin/tsc)
+yarn check:env    # .env.example covers every variable the app requires
 yarn test         # jest
 yarn test -- path/to/file.test.ts     # single file
 yarn db:start / yarn db:stop          # local MySQL 5.7 in Docker
 yarn db:schema                        # prisma migrate dev && prisma generate
 ```
 
-Run `yarn lint` and `yarn tsc` before calling work done. CI runs `yarn lint` on PRs and `yarn tsc` + `yarn test --passWithNoTests` on push (Node 20). A husky pre-commit hook runs `npx pretty-quick --staged`.
+Run `yarn lint` and `yarn tsc` before calling work done. CI runs five checks on Node 20 — `lint`, `tsc`, `test`, `build`, and `env-contract` — on every pull request and on pushes to `main`; [`.github/workflows/`](.github/workflows/) is authoritative for the triggers. `build` runs a real `next build` against placeholder environment values, so a PR can no longer go green while the app fails to build. `env-contract` fails when a variable required by [`src/utils/env/`](src/utils/env/) is missing from `.env.example`. `lint` pins `--max-warnings=0`, which matters because rules like `react-hooks/exhaustive-deps` are warnings rather than errors. A husky pre-commit hook runs `npx pretty-quick --staged`.
 
 There are no test files yet. Jest uses the `ts-jest` preset with the default `node` environment and no setup files — component tests would need `jest-environment-jsdom` and a React testing library added first.
 
@@ -37,7 +38,7 @@ There are no test files yet. Jest uses the `ts-jest` preset with the default `no
 
 - `yarn seed` **wipes the database first**. [`prisma/seed.ts`](prisma/seed.ts) deletes every row from `request`, `carpool_search`, `location`, `group`, `message`, and `user`, then inserts ~70 generated users. It also makes ~140 Mapbox reverse-geocode calls.
 - `yarn build:preview` runs `prisma db push` auto-confirmed with `echo "y"` **and then re-seeds**. It can force-alter a schema and wipe data — never run it to "test the build"; use `yarn build`.
-- `yarn db:schema` runs `prisma migrate dev`, which writes migrations and may prompt to reset the local database on drift.
+- `yarn db:schema` runs `prisma migrate dev`, which writes migrations and may prompt to reset the local database on drift. **If it resets, Prisma runs the seed script automatically** — so this command can wipe and regenerate data without `yarn seed` being typed. Opt out with `npx prisma migrate dev --skip-seed`; appending the flag to `yarn db:schema` does not work, because yarn passes it to `prisma generate` instead.
 - Before running any of these, confirm `DATABASE_URL` targets the local Docker MySQL — not staging, production, or PlanetScale. Ask if unsure.
 - Never run `prisma db push`, `prisma migrate reset`, or a destructive migration without explicit approval. Use `yarn db:schema` for schema work; pushing skips migration history.
 

--- a/docs/development/AI_DEVELOPMENT_WORKFLOW.md
+++ b/docs/development/AI_DEVELOPMENT_WORKFLOW.md
@@ -430,27 +430,47 @@ enforcement by GitHub. See [§17](#17-known-limitations-and-teamadmin-responsibi
 
 ## 14. CI behavior
 
-Current workflows in [`.github/workflows/`](../../.github/workflows/), all on Node 20:
+Current workflows in [`.github/workflows/`](../../.github/workflows/). The five checks all run
+on Node 20; `auto-comment.yml` is not a check and runs no Node of its own:
 
 | Workflow                                                       | Trigger                            | Runs                                                                    |
 | -------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
-| [`lint.yml`](../../.github/workflows/lint.yml)                 | pull request                       | `yarn lint`                                                             |
-| [`tsc.yml`](../../.github/workflows/tsc.yml)                   | push                               | `yarn tsc`                                                              |
-| [`test.yml`](../../.github/workflows/test.yml)                 | push                               | `yarn test --passWithNoTests`                                           |
+| [`lint.yml`](../../.github/workflows/lint.yml)                 | PR + push to `main`                | `yarn lint` (ESLint, `--max-warnings=0`)                                |
+| [`tsc.yml`](../../.github/workflows/tsc.yml)                   | PR + push to `main`                | `yarn tsc`                                                              |
+| [`test.yml`](../../.github/workflows/test.yml)                 | PR + push to `main`                | `yarn test --passWithNoTests`                                           |
+| [`build.yml`](../../.github/workflows/build.yml)               | PR + push to `main`                | `prisma generate`, then `yarn build` against placeholder env values     |
+| [`env-contract.yml`](../../.github/workflows/env-contract.yml) | PR + push to `main`                | `node scripts/check-env-contract.js`                                    |
 | [`auto-comment.yml`](../../.github/workflows/auto-comment.yml) | PR touching `prisma/schema.prisma` | comments a reminder to open a PlanetScale deploy request before merging |
 
-- Lint runs on PRs; type-check and tests on pushes. Separate triggers, so a green PR page is
-  not the same as a green type-check — check both.
-- `--passWithNoTests` is load-bearing: **there are no test files yet.** Tests pass because
-  nothing runs. Component tests would first need `jest-environment-jsdom` and a React testing
-  library (Jest currently uses `ts-jest` with the default `node` environment).
+- All five checks share one trigger policy: **every pull request, plus pushes to `main`.** They
+  deliberately do not run on pushes to other branches — while a PR is open that would run
+  everything twice, once for the push and once for the `pull_request` event. The practical
+  consequence is that pushing a branch with no PR yet gets you no CI feedback.
+- Every job that needs dependencies installs with `yarn install --frozen-lockfile`, so CI tests
+  the locked dependency set rather than whatever resolves that day. `env-contract.yml` is the
+  exception: its check is dependency-free, so it skips installation and stays fast and useful
+  even when installation itself is broken.
+- `build.yml` needs **no secrets.** `next build` imports the envsafe modules, which validate at
+  import time, so the job supplies throwaway placeholder values derived from the env contract
+  itself. Nothing queries the database during a build.
+- `env-contract.yml` exists because those placeholders always satisfy envsafe — a build alone
+  can never notice that a newly required variable was left out of `.env.example`. The check
+  derives the required names from [`src/utils/env/`](../../src/utils/env/) and fails when the
+  template does not document them. Run it locally with `yarn check:env`.
+- `--max-warnings=0` on lint is load-bearing: several rules that matter here, notably
+  `react-hooks/exhaustive-deps`, are warnings rather than errors and would otherwise never
+  fail the check.
+- `--passWithNoTests` is load-bearing in the other direction: **there are no test files yet.**
+  Tests pass because nothing runs. Component tests would first need `jest-environment-jsdom`
+  and a React testing library (Jest currently uses `ts-jest` with the default `node`
+  environment).
 - Whether these checks are _required_ before merge is a branch-protection setting, not
   something CI enforces.
 - A husky pre-commit hook runs `npx pretty-quick --staged` locally.
 
-Because lint and type-check fire on different triggers, **checking CI after the PR exists is
-part of the job** — see [§10](#10-standard-engineering-lifecycle). Inspect with
-`gh pr checks` and `gh run view`; both are read-only and need no approval.
+**Checking CI after the PR exists is part of the job** — see
+[§10](#10-standard-engineering-lifecycle). Inspect with `gh pr checks` and `gh run view`; both
+are read-only and need no approval.
 
 ### Dependency updates
 


### PR DESCRIPTION
## Purpose

[SCRUM-262](https://carpoolnu.atlassian.net/browse/SCRUM-262) — SCRUM-248 added a `build` job and an `env-contract` check and moved every workflow onto one trigger policy, but left the docs describing the old three-check setup. `CLAUDE.md` is loaded into every Claude Code session, so an agent was reading a set of gates that no longer exists.

**Docs only.** No code, config, or dependency changes.

## `CLAUDE.md`

- Names all five checks — `lint`, `tsc`, `test`, `build`, `env-contract` — with the actual trigger policy, and points at `.github/workflows/` as authoritative so future trigger changes don't require an edit here.
- Explains what the two new checks buy you: `build` means a PR can no longer go green while the app fails to build; `env-contract` catches a required variable missing from `.env.example`.
- Notes that `lint` pins `--max-warnings=0`, which matters because `react-hooks/exhaustive-deps` is a *warning*.
- Adds `yarn check:env` to the command list — it existed after SCRUM-248 but was undocumented.

## `docs/development/AI_DEVELOPMENT_WORKFLOW.md` §14

AC 3 asked me to check whether any other doc repeated the stale description. **It did** — §14 had its own workflow table, two workflows short and with the wrong trigger column.

- Adds `build.yml` and `env-contract.yml`; corrects every trigger.
- **Removes obsolete advice.** It said "Lint runs on PRs; type-check and tests on pushes. Separate triggers, so a green PR page is not the same as a green type-check — check both." That reasoning no longer holds now all five share a trigger. Replaced with the current policy *and why* it isn't `on: [push]` (that double-runs everything while a PR is open), plus the practical consequence: pushing a branch with no PR gets no CI feedback.
- Explains why `build.yml` needs no secrets, and why `env-contract.yml` must exist separately from it — placeholders always satisfy `envsafe`, so a build alone can never notice an undocumented variable.
- Corrects "all on Node 20": the five checks are, but `auto-comment.yml` isn't a check and runs no Node of its own.

## AC 2 — re-reading the destructive-command warnings turned up a real gap

The ticket asked me to re-read the `yarn seed` warnings while I was in the file. One was wrong by omission:

> `yarn db:schema` runs `prisma migrate dev`, which writes migrations and may prompt to reset the local database on drift.

**When it resets, Prisma runs the seed script automatically.** So `yarn db:schema` is a third path that can wipe and regenerate data without anyone typing `yarn seed` — and it's the command in the README's normal setup flow. Nothing documented that.

Confirmed against the installed CLI rather than from memory:

```
$ prisma migrate dev --help
    --skip-seed   Skip triggering seed
```

The doc now says so, and gives the opt-out — including the trap that `yarn db:schema --skip-seed` does **not** work, because yarn appends the flag to `prisma generate` instead of `prisma migrate dev`.

This overlaps [SCRUM-212](https://carpoolnu.atlassian.net/browse/SCRUM-212) (seed safety guard), which owns the `README.md` seeding docs and the guard itself. I deliberately did not touch `README.md` — this is only the `CLAUDE.md` accuracy fix that AC 2 authorises.

## Verification

Every factual claim in the new text was checked against the repo, not asserted:

- Five check workflows, all `pull_request` + `push: [main]`, all `node-version: 20` — read from the workflow files.
- The seed warning's table list is **correct as it stood** — verified against the `@@map` names in `schema.prisma` (`request`, `carpool_search`, `location`, `group`, `message`, `user`). `CarpoolGroup` really does map to `group`, so that line needed no change.
- `--skip-seed` valid on both `migrate dev` and `migrate reset`, from `--help`.
- Every link target I added resolves (`.github/workflows/`, `src/utils/env/`, `build.yml`, `env-contract.yml`, `scripts/check-env-contract.js`).
- **No doc still references `next lint`** after SCRUM-261.
- No other tracked doc repeats the old description; the layer READMEs make no CI claims, and `README.md` only links to the workflow guide rather than describing CI.
- `yarn lint`, `yarn tsc`, `yarn check:env` all pass; `prettier --check` clean on both files.

One correction I made mid-review: I had first written "all workflows install with `yarn install --frozen-lockfile`", which is false — `env-contract.yml` deliberately skips installation because its check is dependency-free. Fixed before committing.

## Acceptance criteria

| AC | Status |
|---|---|
| `CLAUDE.md` names all five checks with accurate triggers | Done |
| Re-read the `yarn seed` / destructive-command warnings for accuracy | Done — found and fixed the `db:schema` auto-seed omission; seed table list verified correct as-is |
| Confirm no other doc repeats the old description | Done — found one in `AI_DEVELOPMENT_WORKFLOW.md` §14 and fixed it; `README.md` and the layer READMEs are clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)