### PR TITLE
SCRUM-260: drop husky constructs that fail in v10

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx pretty-quick --staged

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "db:stop": "docker-compose -f docker-compose.yml down",
     "db:schema": "prisma migrate dev && prisma generate",
     "seed": "yarn prisma db seed",
-    "prepare": "husky install",
+    "prepare": "husky",
     "test": "jest",
     "vercel-build": "./vercel.sh",
     "build:preview": "prisma generate && echo \"y\" | prisma db push && next build && yarn prisma db seed",


### PR DESCRIPTION
## Purpose

[SCRUM-260](https://carpoolnu.atlassian.net/browse/SCRUM-260) — husky 9 warns about two constructs this repo still used, and both stop working in v10. The warnings printed on **every commit and every install**, which trains people to ignore husky output — the same channel a real hook failure would use. And with Dependabot now proposing majors individually (SCRUM-181), merging husky v10 would have silently disabled the pre-commit hook: formatting would just stop running, with no error.

## The change

**`.husky/pre-commit`** — 4 lines to 1:

```diff
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx pretty-quick --staged
```

The sourcing line was redundant as well as deprecated: husky 9 already invokes this file through the generated `.husky/_/pre-commit` wrapper, which does that setup itself.

**`package.json`**:

```diff
-"prepare": "husky install",
+"prepare": "husky",
```

**No dependency versions change** — husky stays at `9.1.7`. This only removes the deprecated *usage*, so the eventual v10 bump becomes a no-op.

## Verification — before and after

Both acceptance criteria asked for confirmation rather than assertion, so here it is.

**AC 4 — a fresh install still installs the hooks.** I deleted `node_modules` *and* the generated `.husky/_` first, so this was genuinely from scratch:

| | output |
|---|---|
| before | `$ husky install`<br>`husky - install command is DEPRECATED` |
| after | `$ husky` — no warning |

After the fresh install, husky had regenerated `_/pre-commit`, `_/husky.sh` and `_/h`, and `core.hooksPath` was still `.husky/_` — unchanged, so no developer's git config shifts underneath them.

**AC 3 — a commit still runs `pretty-quick --staged`, with no deprecation warning.** The commit on this branch is itself the test, and it printed no deprecation block (compare any recent commit, which emitted the 6-line `husky - DEPRECATED` notice).

But "no warnings and a green checkmark" would not prove the hook still *does* anything, so I also staged a deliberately misformatted file and committed it:

```
🔍  Finding changed files since f5850ad.
🎯  Found 1 changed file.
✍️  Fixing up src/__huskyprobe.ts.
✅  Everything is awesome!
```

The committed content came out properly formatted, confirming the hook still reformats and re-stages. That throwaway commit was then dropped with `git reset --hard`; the probe file is not in this PR.

**Other checks**, in the same clean worktree: `yarn install --frozen-lockfile` (lockfile unmodified), `yarn lint`, `yarn tsc`, `yarn check:env`, `prisma generate`, `yarn build` — all pass. `yarn test --passWithNoTests` passes **vacuously**; the repo still has no test files, so that is not coverage (SCRUM-211). `prettier --check` clean on `package.json`.

**File mode preserved:** `.husky/pre-commit` was already `100644` (not executable) and still is — the diff carries no mode change, so nothing depends on an exec bit that quietly disappeared.

## Acceptance criteria

| AC | Status |
|---|---|
| Remove the shebang and `husky.sh` sourcing line, leaving the body | Done |
| Change `prepare` from `husky install` to `husky` | Done |
| Confirm a commit still runs `pretty-quick --staged`, no deprecation warning | Done — verified on a real commit, and separately proved it still reformats a misformatted file |
| Confirm a fresh `yarn install` still installs the hooks | Done — with `node_modules` and `.husky/_` both deleted first |

## Note for reviewers

After merging, your next `yarn install` regenerates `.husky/_` with the new wiring. Nothing needs doing by hand, and the deprecation noise on commits and installs should simply stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)