### PR TITLE
SCRUM-257: add security headers and replace deprecated images.domains

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,14 +1,95 @@
 /** @type {import('next').NextConfig} */
+
+/**
+ * Content Security Policy (SCRUM-257).
+ *
+ * Sent as `Content-Security-Policy-Report-Only` on purpose: violations are
+ * reported to the browser console without anything being blocked, so the policy
+ * can be validated against real traffic before it is enforced. Switching the
+ * header name to `Content-Security-Policy` is the enforcement step, and should
+ * only happen once a deployed environment has been exercised — map, chat,
+ * profile picture upload and sign-in — with no violations reported.
+ *
+ * Each non-obvious source is here for a reason:
+ *
+ * - `'unsafe-inline'` in script-src: the Pages Router inlines the
+ *   `__NEXT_DATA__` hydration payload. Removing it needs per-request nonces,
+ *   which this app has no middleware to generate.
+ * - `'unsafe-eval'` in script-src: mapbox-gl evaluates style expressions.
+ * - `'unsafe-inline'` in style-src: styled-components, MUI/emotion and Ant
+ *   Design all inject inline <style> tags at runtime.
+ * - fonts.googleapis.com / fonts.gstatic.com: Lato and Montserrat are loaded as
+ *   remote stylesheets in src/pages/_document.tsx, not self-hosted.
+ * - blob: in worker-src and img-src: mapbox-gl runs its renderer in a worker
+ *   created from a blob URL.
+ * - `*.pusher.com` over wss: the realtime cluster is configured through
+ *   NEXT_PUBLIC_PUSHER_CLUSTER, so the subdomain is not fixed at build time.
+ * - `*.mapbox.com` covers both api.mapbox.com (tiles, geocoding, directions)
+ *   and events.mapbox.com (mapbox-gl telemetry).
+ */
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "font-src 'self' data: https://fonts.gstatic.com",
+  "img-src 'self' data: blob: https://lh3.googleusercontent.com https://carpoolnubucket.s3.us-east-2.amazonaws.com https://*.mapbox.com",
+  "connect-src 'self' https://*.mapbox.com https://*.mixpanel.com https://*.pusher.com wss://*.pusher.com",
+  "worker-src 'self' blob:",
+  "child-src 'self' blob:",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+].join("; ");
+
+const securityHeaders = [
+  // No part of the app is meant to be framed, and it has no iframes of its own.
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  // Browsers ignore this over plain HTTP, so it is inert in local development.
+  // `includeSubDomains` and `preload` are deliberately omitted: both affect
+  // hostnames beyond this app and are a decision for whoever owns the domain.
+  { key: "Strict-Transport-Security", value: "max-age=63072000" },
+  // The app requests none of these. Nothing uses navigator.geolocation, and the
+  // map has no GeolocateControl.
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=()",
+  },
+  { key: "Content-Security-Policy-Report-Only", value: contentSecurityPolicy },
+];
+
 const nextConfig = {
   reactStrictMode: true,
+  // Do not advertise the framework and its version.
+  poweredByHeader: false,
   images: {
-    domains: [
-      "lh3.googleusercontent.com",
-      "carpoolnubucket.s3.us-east-2.amazonaws.com",
+    // `images.domains` is deprecated in favour of remotePatterns.
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
+        hostname: "carpoolnubucket.s3.us-east-2.amazonaws.com",
+        pathname: "/**",
+      },
     ],
   },
   compiler: {
     styledComponents: true,
+  },
+  async headers() {
+    return [
+      {
+        // Every route, including /api and Next's own assets.
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
## Purpose

[SCRUM-257](https://carpoolnu.atlassian.net/browse/SCRUM-257) — the app shipped **no** response security headers, advertised `X-Powered-By: Next.js`, and configured remote images with the deprecated `images.domains`. One file changed: `next.config.js`.

## Enforced headers

All verified against the code before enabling, so none of them can regress a feature:

| Header | Value | Why it's safe here |
|---|---|---|
| `X-Frame-Options` | `DENY` | Nothing in `src/` renders an iframe |
| `X-Content-Type-Options` | `nosniff` | — |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | — |
| `Strict-Transport-Security` | `max-age=63072000` | Ignored by browsers over plain HTTP, so inert locally |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Nothing calls `navigator.geolocation`; the map has no `GeolocateControl` |

**HSTS deliberately omits `includeSubDomains` and `preload`.** Both reach hostnames beyond this app, `preload` is painful to reverse, and per SCRUM-249 the deployment target isn't even recorded in the repo. That's a decision for whoever owns the domain — easy to add later, hard to undo.

`poweredByHeader: false` removes `X-Powered-By`.

## CSP — report-only, and derived from the code

Ships as `Content-Security-Policy-Report-Only` per the ticket, so **it cannot break anything at runtime**; violations only surface in the browser console. Every source was traced in the codebase rather than copied from a template, and two would be easy to miss:

- **Google Fonts are remote.** Lato and Montserrat load as stylesheets from `fonts.googleapis.com` with font files from `fonts.gstatic.com` ([_document.tsx](src/pages/_document.tsx), [_app.tsx](src/pages/_app.tsx)). A generic `style-src 'self'` policy would silently strip the app's typography.
- **The Pusher subdomain isn't fixed at build time** — the cluster comes from `NEXT_PUBLIC_PUSHER_CLUSTER`, so the policy uses `*.pusher.com` over both `https` and `wss` rather than a hardcoded cluster.

The rest, each commented in the file with its reason: `mapbox-gl` needs `'unsafe-eval'` and `blob:` workers; styled-components, MUI/emotion and Ant Design all inject inline styles; the Pages Router inlines the `__NEXT_DATA__` hydration payload, so `script-src` needs `'unsafe-inline'` until there's middleware to issue per-request nonces. `*.mapbox.com` covers both `api.mapbox.com` and `events.mapbox.com` (telemetry). Mixpanel is the npm package, not a CDN script, so it needs `connect-src` only.

## `images.remotePatterns`

Replaces `images.domains` for the same two hosts. Verified through the image optimizer, which distinguishes authorisation from fetch failure:

| host | result |
|---|---|
| `lh3.googleusercontent.com` | `"url" parameter is **valid**` (only the fake path failed) |
| `carpoolnubucket.s3...amazonaws.com` | `"url" parameter is **valid**` |
| `evil.example.com` (control) | `"url" parameter is **not allowed**` |

So the two intended hosts are authorised and others are rejected.

## Verification

Built for production and curled a **real running server** (`next start`), rather than trusting the config:

- All six headers present on a page route (`/sign-in`, 200) **and** an API route (`/api/auth/session`) — the `headers()` source pattern covers `/api` too.
- `X-Powered-By`: **0 occurrences**.
- CSP arrives as `Content-Security-Policy-Report-Only`, not enforcing.
- The sign-in page's only external resources are `fonts.googleapis.com` and `fonts.gstatic.com` — both permitted, in the correct directives.

Also `yarn lint`, `yarn tsc`, `yarn check:env`, `yarn build`, `prettier --check` all pass. `yarn test --passWithNoTests` passes **vacuously** — no test files exist, so not coverage (SCRUM-211). The server was stopped and the port confirmed free.

## Acceptance criteria

| AC | Status |
|---|---|
| `headers()` with frame/nosniff/referrer/HSTS | Done |
| CSP added in report-only, validated against Mapbox, Mixpanel, Pusher, styled-components | **Partly** — policy derived from those four and shipped report-only; browser-level validation needs a session (see below) |
| `images.domains` → `remotePatterns`, avatars still render | Mechanism verified via the optimizer; actual rendering needs real data |
| `poweredByHeader: false` | Done |
| Headers verified on a deployed environment | **Not done — cannot be done from the repo** |

## What this PR cannot establish

Being explicit, since this is a security change:

- **No deployed-environment verification.** I have no deploy access, so the last AC is genuinely unmet. Someone should curl the headers on staging after this merges.
- **The CSP has not been exercised in a browser against the real app.** Only `/sign-in` is reachable without an authenticated Azure AD session, so Mapbox, Pusher and the chat UI were never loaded. Their sources were derived by reading the code, not observed. **This is exactly why it ships report-only** — but it means the policy should be treated as a first draft.
- **Enforcement is a separate, later step:** collect report-only data from a real deployment (map, chat, profile-picture upload, sign-in), then rename the header to `Content-Security-Policy`. There is no report collector, so violations currently appear only in the browser console; adding a `report-to` endpoint would be a reasonable follow-up.
- The hardcoded bucket name in the CSP and `remotePatterns` mirrors what was already in this file. Making it per-environment is [SCRUM-247](https://carpoolnu.atlassian.net/browse/SCRUM-247), deliberately not widened into here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)