### PR TITLE
SCRUM-255: move local MySQL from 5.7 (EOL) to 8.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ yarn tsc          # type check (no npm script; resolves node_modules/.bin/tsc)
 yarn check:env    # .env.example covers every variable the app requires
 yarn test         # jest
 yarn test -- path/to/file.test.ts     # single file
-yarn db:start / yarn db:stop          # local MySQL 5.7 in Docker
+yarn db:start / yarn db:stop          # local MySQL 8.0 in Docker
 yarn db:schema                        # prisma migrate dev && prisma generate
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,31 @@ Ask a maintainer for development credentials. The app validates these at startup
 Then start the database, set up the schema, and run the app:
 
 ```bash
-yarn db:start     # local MySQL in Docker
+yarn db:start     # local MySQL 8.0 in Docker
 yarn db:schema    # prisma migrate dev && prisma generate
 yarn seed         # optional: populate with generated users
 yarn dev
 ```
 
 The app runs at <http://localhost:3000>. `yarn startup` runs `yarn db:start` and `yarn dev` together.
+
+### Upgrading an existing local database
+
+The local container tracks MySQL 8.0 to match the major version PlanetScale serves. It was previously pinned to 5.7. On first start, 8.0 attempts an in-place upgrade of a 5.7 data directory — but that upgrade only succeeds if 5.7 shut down cleanly. If the container was ever force-stopped, InnoDB refuses (`Upgrade is not supported after a crash or shutdown with innodb_fast_shutdown = 2`) and the container exits 1.
+
+Chasing a clean-shutdown upgrade is not worth it for generated development data. If you set this project up before the version change, replace the data directory once:
+
+```bash
+yarn db:stop
+mv nucarpool-db-data nucarpool-db-data.mysql57-backup   # or delete it outright
+yarn db:start                                           # 8.0 initializes a fresh data directory
+yarn db:schema                                          # apply all migrations
+yarn seed                                               # optional: regenerate sample users
+```
+
+This discards your local rows. That is safe — the directory is gitignored, holds only generated development data, and `yarn seed` recreates it. Nothing on PlanetScale is affected. Once the new container is up, `rm -rf nucarpool-db-data.mysql57-backup` to reclaim the space.
+
+On Apple Silicon the container now runs natively rather than under x86 emulation, because 8.0 publishes an arm64 image and 5.7 did not.
 
 ## Environment Variables
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
-version: "3"
-
 services:
   mysql:
-    platform: linux/x86_64
     container_name: mysql-on-docker
-    image: mysql:5.7
+    # MySQL 8.0 matches the major version PlanetScale serves, so migrations are
+    # exercised against equivalent behaviour before the deploy request. 8.0 also
+    # publishes a native linux/arm64 image, which is why there is no `platform:`
+    # override here — 5.7 was amd64-only and ran emulated on Apple Silicon.
+    image: mysql:8.0
     ports:
       - "${MYSQL_PORT}:3306"
     expose:
@@ -13,7 +14,8 @@ services:
       MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
       MYSQL_DATABASE: "${MYSQL_DATABASE}"
     volumes:
+      # A bind mount, not a named volume: the data directory sits in the
+      # repository root and is gitignored. 8.0 only starts on a data directory
+      # left by 5.7 if 5.7 shut down cleanly, so an existing one usually has to
+      # be replaced — see "Upgrading an existing local database" in README.md.
       - ./nucarpool-db-data:/var/lib/mysql
-
-volumes:
-  nucarpool-db-data:

--- a/docs/development/AI_DEVELOPMENT_WORKFLOW.md
+++ b/docs/development/AI_DEVELOPMENT_WORKFLOW.md
@@ -85,7 +85,7 @@ Prerequisites: Node 20 (CI uses 20), Docker, Yarn Classic 1.x, git.
 ```bash
 git clone <repo-url> && cd nucarpool
 yarn                  # Yarn Classic — not npm, not pnpm
-yarn db:start         # local MySQL 5.7 in Docker
+yarn db:start         # local MySQL 8.0 in Docker
 yarn dev              # http://localhost:3000
 ```
 


### PR DESCRIPTION
Jira: [SCRUM-255](https://carpoolnu.atlassian.net/browse/SCRUM-255)

## Why

MySQL 5.7 reached end of life in October 2023, and its Docker image has not been rebuilt since **2023-12-15**. PlanetScale serves MySQL 8, so local development was validating schema and query behaviour against a different, unsupported major version than the one that serves users — migrations were authored against 5.7 and only met MySQL 8 at the deploy request.

## What changed

`docker-compose.yml` is the only functional change:

| Before | After | Reason |
| --- | --- | --- |
| `image: mysql:5.7` | `image: mysql:8.0` | Matches the production major version; 5.7 is EOL |
| `platform: linux/x86_64` | removed | 5.7 ships an **amd64-only** manifest, so Apple Silicon emulated it. 8.0 has a native `linux/arm64` image |
| `version: "3"` | removed | Obsolete under Compose v2 — it warns and ignores the key |
| trailing `volumes:` block | removed | Declared a named volume `nucarpool-db-data` that nothing referenced; the service bind-mounts `./nucarpool-db-data` |

Documentation: `README.md` gains **Upgrading an existing local database** (the one-time data-directory reset), and the stale `MySQL 5.7` comments in `CLAUDE.md` and `docs/development/AI_DEVELOPMENT_WORKFLOW.md` are corrected.

No change to `schema.prisma`, any migration, application code, `package.json`, or `dependabot.yml`.

## Verification

Run against real containers, not by inspection. All test containers and volumes were removed afterwards.

- **Migrations apply cleanly on MySQL 8** — all 26 migrations via `prisma migrate deploy` against a fresh, empty database on **8.0.46**: `All migrations have been successfully applied.`, 12 tables created. Also confirmed on **8.4.11** while evaluating the tag choice; resulting schema collation was byte-identical between the two.
- **Prisma works with MySQL 8 auth** — 4.16.2 connects with no extra configuration despite MySQL 8 defaulting to `caching_sha2_password` (5.7 used `mysql_native_password`).
- **Collation is equivalent to production** — every `CREATE TABLE` in the migrations pins `DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`, so all 12 tables and every text column carry `utf8mb4_unicode_ci` regardless of server version. The server default is `utf8mb4_0900_ai_ci`, but **zero tables and zero columns inherit it**, so the 5.7-vs-8.0 default-collation difference has no effect on this schema.
- **Native arm64, no emulation** — booting the committed compose config reports `@@version = 8.0.46`, `@@version_compile_machine = aarch64`.
- **Compose warning is gone** — `docker compose config` on the previous file emits the `version` is obsolete warning; on this file it emits none.
- **Fresh bind mount works on macOS** — 8.0 initialized a new `./nucarpool-db-data` (27 entries, 104 MB) and accepted all migrations through the committed configuration.
- `yarn lint`, `yarn tsc`, `yarn check:env`, and `prettier --check` all pass. `yarn test` passes vacuously — there are still no test files, which is not coverage.

## Known limitations and risks

- **AC2 is not fully satisfied: I could not confirm which MySQL version PlanetScale is actually serving.** That lives in the PlanetScale branch settings, which I have no access to. `8.0` was chosen as the likeliest match (PlanetScale's default for MySQL 8 databases, and this database dates from 2022) and confirmed with the requester. **Please verify in the dashboard before merging.** If it turns out to be 8.4, the fix is one token — `image: mysql:8.4` — and migrations are already proven to apply there.
- **Worth knowing when choosing:** the `mysql:8.0` image's last rebuild was **2026-05-05**, whereas `mysql:8.4` (the current `lts` tag) was rebuilt **2026-07-28**. Version parity was prioritised over patch recency; if the team later prefers tracking LTS, that is a deliberate follow-up, not an oversight here.
- **This is a breaking change for existing developers.** An existing 5.7 data directory generally cannot be carried over: 8.0 attempts an in-place upgrade and InnoDB refuses it if 5.7 did not shut down cleanly (`Upgrade is not supported after a crash or shutdown with innodb_fast_shutdown = 2`), leaving the container exited 1. Tested against a *copy* of a real 5.7 data directory from this project, which failed in exactly that way. The README reset procedure discards only gitignored generated development data; nothing on PlanetScale is affected.
- **`platform` removal is unverified on amd64 hosts.** `mysql:8.0` publishes both `linux/amd64` and `linux/arm64/v8`, so Intel and Linux developers get a native image too, but I only tested on `aarch64`.
- CI does not apply migrations, so nothing here is exercised by a workflow — the verification above was manual and is not repeated automatically.

## Related

- SCRUM-210 (local database setup documentation) — the README section added here is the migration-specific part of that; the broader setup rewrite is still open.
- Nothing was force-stopped, reset, or seeded. The requester's stopped `mysql-on-docker` container and its 226 MB data directory were left untouched, and their unrelated uncommitted work on `.github/dependabot.yml` and `yarn.lock` is deliberately excluded from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)