### PR TITLE
SCRUM-212: refuse to seed a non-local database

### DIFF
--- a/.claude/skills/jira-ticket/SKILL.md
+++ b/.claude/skills/jira-ticket/SKILL.md
@@ -88,8 +88,10 @@ Run what the change warrants — normally `yarn lint` and `yarn tsc`, plus `yarn
 relevant, and any task-specific checks (for docs: formatting, link and anchor resolution, a
 secrets scan).
 
-**Report test results honestly.** There is currently no test suite, so `yarn test` passes
-because nothing runs. That is a vacuous pass, not coverage — never present it as coverage.
+**Report test results honestly.** The suite covers one module — the seed guard
+(`src/utils/seedGuard.test.ts`). A passing `yarn test` therefore says nothing about
+components, routers, or pages, so never present it as coverage of anything you did not
+actually test.
 
 Failure caused by your change → fix it and revalidate. Failure that is unrelated → the
 discovered-issue workflow below; do not expand scope.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --frozen-lockfile
-      # --passWithNoTests keeps this green while the repo has no test files, so
-      # this gate currently proves nothing. Adding real tests is SCRUM-211.
-      - run: yarn test --passWithNoTests
+      # --passWithNoTests was dropped with SCRUM-212, which added the first test
+      # files. An empty run should now fail rather than pass silently. Broader
+      # end-to-end coverage is still SCRUM-211.
+      - run: yarn test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ yarn db:schema                        # prisma migrate dev && prisma generate
 
 Run `yarn lint` and `yarn tsc` before calling work done. CI runs five checks on Node 20 — `lint`, `tsc`, `test`, `build`, and `env-contract` — on every pull request and on pushes to `main`; [`.github/workflows/`](.github/workflows/) is authoritative for the triggers. `build` runs a real `next build` against placeholder environment values, so a PR can no longer go green while the app fails to build. `env-contract` fails when a variable required by [`src/utils/env/`](src/utils/env/) is missing from `.env.example`. `lint` pins `--max-warnings=0`, which matters because rules like `react-hooks/exhaustive-deps` are warnings rather than errors. A husky pre-commit hook runs `npx pretty-quick --staged`.
 
-There are no test files yet. Jest uses the `ts-jest` preset with the default `node` environment and no setup files — component tests would need `jest-environment-jsdom` and a React testing library added first.
+Test coverage is narrow but no longer empty: [`src/utils/seedGuard.test.ts`](src/utils/seedGuard.test.ts) is the only suite, and `test.yml` no longer passes `--passWithNoTests`, so an empty run fails. Jest uses the `ts-jest` preset with the default `node` environment and no setup files — component tests would need `jest-environment-jsdom` and a React testing library added first. A passing `yarn test` still says nothing about components, routers, or pages.
 
 ## Safety
 
@@ -37,6 +37,7 @@ There are no test files yet. Jest uses the `ts-jest` preset with the default `no
 **Database — these commands destroy data**
 
 - `yarn seed` **wipes the database first**. [`prisma/seed.ts`](prisma/seed.ts) deletes every row from `request`, `carpool_search`, `location`, `group`, `message`, and `user`, then inserts ~70 generated users. It also makes ~140 Mapbox reverse-geocode calls.
+- [`src/utils/seedGuard.ts`](src/utils/seedGuard.ts) refuses to seed a non-local host, fails closed on a missing or unparseable `DATABASE_URL`, and covers all three seed paths because it runs inside `seed.ts` itself. `SEED_ALLOW_REMOTE=1` overrides it. **The guard does not relax any rule here** — seed commands remain denied in [`.claude/settings.json`](.claude/settings.json), and the override must never be set to make something work.
 - `yarn build:preview` runs `prisma db push` auto-confirmed with `echo "y"` **and then re-seeds**. It can force-alter a schema and wipe data — never run it to "test the build"; use `yarn build`.
 - `yarn db:schema` runs `prisma migrate dev`, which writes migrations and may prompt to reset the local database on drift. **If it resets, Prisma runs the seed script automatically** — so this command can wipe and regenerate data without `yarn seed` being typed. Opt out with `npx prisma migrate dev --skip-seed`; appending the flag to `yarn db:schema` does not work, because yarn passes it to `prisma generate` instead.
 - Before running any of these, confirm `DATABASE_URL` targets the local Docker MySQL — not staging, production, or PlanetScale. Ask if unsure.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Then start the database, set up the schema, and run the app:
 ```bash
 yarn db:start     # local MySQL 8.0 in Docker
 yarn db:schema    # prisma migrate dev && prisma generate
-yarn seed         # optional: populate with generated users
+yarn seed         # optional: DELETES all rows, then inserts generated users
 yarn dev
 ```
 
@@ -63,6 +63,39 @@ This discards your local rows. That is safe — the directory is gitignored, hol
 
 On Apple Silicon the container now runs natively rather than under x86 emulation, because 8.0 publishes an arm64 image and 5.7 did not.
 
+### Seeding resets your local data
+
+`yarn seed` is **not additive**. Before inserting anything, [`prisma/seed.ts`](prisma/seed.ts) deletes every row from `request`, `carpool_search`, `location`, `group`, `message` and `user`, then inserts about 70 generated users with fixed ids and 10 groups. It also makes roughly 140 Mapbox reverse-geocode calls, which consume API quota.
+
+Three commands reach that script, not one:
+
+| Command              | How it seeds                                                                                          |
+| -------------------- | ----------------------------------------------------------------------------------------------------- |
+| `yarn seed`          | Directly                                                                                              |
+| `yarn build:preview` | Force-pushes the schema, then re-seeds                                                                |
+| `yarn db:schema`     | Only if `prisma migrate dev` resets the database — **Prisma then runs the seed script automatically** |
+
+The third is the surprising one, because it is part of normal setup. To apply migrations without seeding, run `npx prisma migrate dev --skip-seed`; appending the flag to `yarn db:schema` does not work, because yarn passes it to `prisma generate` instead.
+
+Because the script writes to whatever `DATABASE_URL` points at, [`src/utils/seedGuard.ts`](src/utils/seedGuard.ts) checks the target host before the first delete and refuses anything that is not local:
+
+```
+Refusing to seed.
+
+DATABASE_URL points at the non-local host "aws.connect.psdb.cloud".
+...
+```
+
+Allowed hosts are `localhost`, `127.0.0.1`, `::1`, `0.0.0.0`, `mysql` and `mysql-on-docker`. The guard fails closed — a missing or unparseable `DATABASE_URL` is refused rather than assumed local — and compares the hostname only, so a password containing `localhost` cannot fake a match. To extend the list, edit `LOCAL_HOSTNAMES` in that file.
+
+If you genuinely need to seed a non-local database, opt in for that single command:
+
+```bash
+SEED_ALLOW_REMOTE=1 yarn seed
+```
+
+Think carefully before you do. Against staging or production this deletes every user, group, message, request, location and carpool search, and the app cannot undo it. `yarn build:preview` is deliberately **not** given the override, so it now fails the guard if it is ever pointed at a remote database.
+
 ## Environment Variables
 
 [`.env.example`](.env.example) is the authoritative list. It documents every variable, grouped by service, with placeholder values and notes on which are optional. Copy it to `.env` and fill in real values — never commit them, and keep placeholders only in `.env.example` itself. `.env` is gitignored.
@@ -78,17 +111,17 @@ Validation runs at import time in [`src/utils/env/browser.ts`](src/utils/env/bro
 
 ## Useful Commands
 
-| Command                          | Purpose                                           |
-| -------------------------------- | ------------------------------------------------- |
-| `yarn dev`                       | Start the development server on port 3000         |
-| `yarn startup`                   | Start the local database, then the dev server     |
-| `yarn build`                     | Production build                                  |
-| `yarn lint`                      | Run ESLint                                        |
-| `yarn tsc`                       | Type check                                        |
-| `yarn test`                      | Run Jest (no test files exist yet)                |
-| `yarn db:start` / `yarn db:stop` | Start / stop the local MySQL container            |
-| `yarn db:schema`                 | Apply migrations and regenerate the Prisma client |
-| `yarn seed`                      | Populate the database with generated users        |
+| Command                          | Purpose                                              |
+| -------------------------------- | ---------------------------------------------------- |
+| `yarn dev`                       | Start the development server on port 3000            |
+| `yarn startup`                   | Start the local database, then the dev server        |
+| `yarn build`                     | Production build                                     |
+| `yarn lint`                      | Run ESLint                                           |
+| `yarn tsc`                       | Type check                                           |
+| `yarn test`                      | Run Jest (unit tests for the seed guard)             |
+| `yarn db:start` / `yarn db:stop` | Start / stop the local MySQL container               |
+| `yarn db:schema`                 | Apply migrations and regenerate the Prisma client    |
+| `yarn seed`                      | **Wipes** the database, then inserts generated users |
 
 ## Documentation
 

--- a/docs/development/AI_DEVELOPMENT_WORKFLOW.md
+++ b/docs/development/AI_DEVELOPMENT_WORKFLOW.md
@@ -437,7 +437,7 @@ on Node 20; `auto-comment.yml` is not a check and runs no Node of its own:
 | -------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
 | [`lint.yml`](../../.github/workflows/lint.yml)                 | PR + push to `main`                | `yarn lint` (ESLint, `--max-warnings=0`)                                |
 | [`tsc.yml`](../../.github/workflows/tsc.yml)                   | PR + push to `main`                | `yarn tsc`                                                              |
-| [`test.yml`](../../.github/workflows/test.yml)                 | PR + push to `main`                | `yarn test --passWithNoTests`                                           |
+| [`test.yml`](../../.github/workflows/test.yml)                 | PR + push to `main`                | `yarn test` (Jest)                                                      |
 | [`build.yml`](../../.github/workflows/build.yml)               | PR + push to `main`                | `prisma generate`, then `yarn build` against placeholder env values     |
 | [`env-contract.yml`](../../.github/workflows/env-contract.yml) | PR + push to `main`                | `node scripts/check-env-contract.js`                                    |
 | [`auto-comment.yml`](../../.github/workflows/auto-comment.yml) | PR touching `prisma/schema.prisma` | comments a reminder to open a PlanetScale deploy request before merging |
@@ -460,10 +460,12 @@ on Node 20; `auto-comment.yml` is not a check and runs no Node of its own:
 - `--max-warnings=0` on lint is load-bearing: several rules that matter here, notably
   `react-hooks/exhaustive-deps`, are warnings rather than errors and would otherwise never
   fail the check.
-- `--passWithNoTests` is load-bearing in the other direction: **there are no test files yet.**
-  Tests pass because nothing runs. Component tests would first need `jest-environment-jsdom`
-  and a React testing library (Jest currently uses `ts-jest` with the default `node`
-  environment).
+- `test` runs real tests as of SCRUM-212, which added unit tests for the seed guard
+  ([`src/utils/seedGuard.test.ts`](../../src/utils/seedGuard.test.ts)) and dropped
+  `--passWithNoTests`, so an empty run now fails instead of passing silently. Coverage is
+  still narrow — one module, no component or end-to-end tests. Component tests would first
+  need `jest-environment-jsdom` and a React testing library, since Jest uses `ts-jest` with
+  the default `node` environment. Broader coverage is SCRUM-211.
 - Whether these checks are _required_ before merge is a branch-protection setting, not
   something CI enforces.
 - A husky pre-commit hook runs `npx pretty-quick --staged` locally.
@@ -501,6 +503,10 @@ ecosystem (`package.json` and `yarn.lock`) and for the actions pinned in
   `yarn build:preview` force-pushes the schema and re-seeds. Never run `build:preview` to
   "test the build" — use `yarn build`. Confirm `DATABASE_URL` targets local Docker MySQL
   before any schema or seed command. Both are denied in settings for a reason.
+  [`src/utils/seedGuard.ts`](../../src/utils/seedGuard.ts) additionally refuses to seed any
+  host outside a local allowlist, so a misdirected `DATABASE_URL` fails loudly instead of
+  wiping a shared database. Treat that guard as a backstop, not as permission to run seed
+  commands — the deny rules still apply.
 - **External services with real side effects.** Email procedures send real mail via AWS SES;
   messaging fires real Pusher events; Mapbox calls consume quota. Verify which environment
   your credentials point at first.
@@ -544,7 +550,8 @@ ecosystem (`package.json` and `yarn.lock`) and for the actions pinned in
 **Open items a future developer may pick up:**
 
 - Confirm and document branch protection once someone has admin access.
-- There is no test suite yet, so `test.yml` is a placeholder in practice.
+- Test coverage is narrow: `test.yml` now runs real tests, but only for the seed guard. No
+  component, router, or end-to-end coverage exists (SCRUM-211).
 
 Everything else in this document describes **current** behavior; only the items above are open
 or planned.

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@types/cropperjs": "^1.3.0",
     "@types/file-saver": "^2.0.7",
     "@types/geojson": "7946.0.16",
+    "@types/jest": "29.5.14",
     "@types/lodash": "4.17.20",
     "@types/mapbox__polyline": "^1.0.2",
     "@types/mapbox-gl": "2.7.21",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,6 +3,11 @@ import { range } from "lodash";
 import Random from "random-seed";
 import { generateUser, GenerateUserInput } from "../src/utils/recommendation";
 import { timeEnd } from "console";
+import {
+  assertSeedTargetIsLocal,
+  SEED_OVERRIDE_ENV,
+  SeedGuardError,
+} from "../src/utils/seedGuard";
 
 const prisma = new PrismaClient();
 
@@ -207,7 +212,9 @@ const pickConnections = (
 /**
  * Generates favorites between users in our database.
  */
-const generateGroups = async (userIds: string[]): Promise<Map<string, string>> => {
+const generateGroups = async (
+  userIds: string[],
+): Promise<Map<string, string>> => {
   const userToGroupMap = new Map<string, string>();
   const groups: string[][] = [];
   let i = 0;
@@ -304,30 +311,31 @@ const createUserData = async () => {
     }),
   ]);
 
-  const usersData: GeneratedUserData[] = userGroups.flat().map((user, index) => ({
-    id: index.toString(),
-    ...user,
-  }));
+  const usersData: GeneratedUserData[] = userGroups
+    .flat()
+    .map((user, index) => ({
+      id: index.toString(),
+      ...user,
+    }));
 
   await clearConnections();
   await deleteAllData();
-  
+
   // Create users with only non-migrated fields
   await Promise.all(
     usersData.map((userData) =>
-      prisma.user.upsert(generateUser({ id: userData.id } as GenerateUserInput & { id: string })),
+      prisma.user.upsert(
+        generateUser({ id: userData.id } as GenerateUserInput & { id: string }),
+      ),
     ),
   );
-  
-  const userIds = usersData.map(u => u.id);
-  
+
+  const userIds = usersData.map((u) => u.id);
+
   // Generate groups and get the userId -> groupId mapping
   const userToGroupMap = await generateGroups(userIds);
-  
-  await Promise.all([
-    generateFavorites(userIds),
-    generateRequests(userIds),
-  ]);
+
+  await Promise.all([generateFavorites(userIds), generateRequests(userIds)]);
 
   // create Location and CarpoolSearch records for each user
   for (const userData of usersData) {
@@ -342,7 +350,7 @@ const createUserData = async () => {
             street: userData.startStreet,
             city: userData.startCity,
             state: userData.startState,
-            streetAddress: userData.startAddress || '',
+            streetAddress: userData.startAddress || "",
           },
         });
       }
@@ -351,10 +359,10 @@ const createUserData = async () => {
       if (!homeLocation) {
         homeLocation = await prisma.location.create({
           data: {
-            street: userData.startStreet || '',
-            city: userData.startCity || '',
-            state: userData.startState || '',
-            streetAddress: userData.startAddress || '',
+            street: userData.startStreet || "",
+            city: userData.startCity || "",
+            state: userData.startState || "",
+            streetAddress: userData.startAddress || "",
             coordLng: userData.startCoordLng,
             coordLat: userData.startCoordLat,
           },
@@ -365,13 +373,17 @@ const createUserData = async () => {
       let companyLocation = null;
 
       // only search for existing location if we have valid address data
-      if (userData.companyStreet && userData.companyCity && userData.companyState) {
+      if (
+        userData.companyStreet &&
+        userData.companyCity &&
+        userData.companyState
+      ) {
         companyLocation = await prisma.location.findFirst({
           where: {
             street: userData.companyStreet,
             city: userData.companyCity,
             state: userData.companyState,
-            streetAddress: userData.companyAddress || '',
+            streetAddress: userData.companyAddress || "",
           },
         });
       }
@@ -380,10 +392,10 @@ const createUserData = async () => {
       if (!companyLocation) {
         companyLocation = await prisma.location.create({
           data: {
-            street: userData.companyStreet || '',
-            city: userData.companyCity || '',
-            state: userData.companyState || '',
-            streetAddress: userData.companyAddress || '',
+            street: userData.companyStreet || "",
+            city: userData.companyCity || "",
+            state: userData.companyState || "",
+            streetAddress: userData.companyAddress || "",
             coordLng: userData.companyCoordLng,
             coordLat: userData.companyCoordLat,
           },
@@ -394,7 +406,9 @@ const createUserData = async () => {
       const carpoolId = userToGroupMap.get(userData.id) || null;
 
       // Parse time strings to Date objects
-      const startTimeDate = userData.startTime ? new Date(userData.startTime) : null;
+      const startTimeDate = userData.startTime
+        ? new Date(userData.startTime)
+        : null;
       const endTimeDate = userData.endTime ? new Date(userData.endTime) : null;
 
       // create CarpoolSearch
@@ -405,7 +419,7 @@ const createUserData = async () => {
           status: "ACTIVE",
           seatsAvail: userData.seatAvail || 0,
           companyName: "Sandbox Inc.",
-          daysWorking: userData.daysWorking || '',
+          daysWorking: userData.daysWorking || "",
           startTime: startTimeDate,
           endTime: endTimeDate,
           startDate: userData.coopStartDate,
@@ -417,7 +431,10 @@ const createUserData = async () => {
         },
       });
     } catch (error) {
-      console.error(`Failed to create CarpoolSearch for user ${userData.id}:`, error);
+      console.error(
+        `Failed to create CarpoolSearch for user ${userData.id}:`,
+        error,
+      );
     }
   }
 };
@@ -541,15 +558,36 @@ const addFavorites = async (userId: string, ids: string[]) => {
  * Populates our database with fake data.
  */
 const main = async () => {
+  // First statement in the script. createUserData() wipes six tables, and it is
+  // reached by `yarn seed`, by `yarn build:preview`, and by a database reset
+  // during `yarn db:schema`. Refuse anything that is not a local database before
+  // doing any work — this also avoids the ~140 Mapbox geocode calls further down.
+  const target = assertSeedTargetIsLocal();
+
+  if (target.reason === "override") {
+    console.warn(
+      `WARNING: ${SEED_OVERRIDE_ENV} is set. Seeding the NON-LOCAL host "${target.hostname}" and deleting its existing rows.`,
+    );
+  } else {
+    console.log(
+      `Seeding "${target.hostname}". Existing rows will be deleted first.`,
+    );
+  }
+
   await createUserData();
 };
 
 main()
   .catch((e) => {
-    console.error(e);
+    // A guard refusal is an expected, self-explanatory message rather than a
+    // crash, so print it without a stack trace that would bury the reason.
+    if (e instanceof SeedGuardError) {
+      console.error(e.message);
+    } else {
+      console.error(e);
+    }
     process.exit(1);
   })
   .finally(async () => {
     await prisma.$disconnect();
   });
-  

--- a/src/server/db/README.md
+++ b/src/server/db/README.md
@@ -5,7 +5,7 @@ This directory holds the Prisma client the rest of the app shares. The schema, m
 - [`client.ts`](./client.ts) — creates and exports the `PrismaClient` singleton
 - [`../../../prisma/schema.prisma`](../../../prisma/schema.prisma) — the data model
 - [`../../../prisma/migrations/`](../../../prisma/migrations) — ordered SQL migrations
-- [`../../../prisma/seed.ts`](../../../prisma/seed.ts) — generated data for local development
+- [`../../../prisma/seed.ts`](../../../prisma/seed.ts) — generated data for local development. **Destructive**: it deletes every row from six tables before inserting. [`../../utils/seedGuard.ts`](../../utils/seedGuard.ts) refuses to run it against any host outside a local allowlist; see [Seeding resets your local data](../../../README.md#seeding-resets-your-local-data).
 
 ## The client
 

--- a/src/utils/seedGuard.test.ts
+++ b/src/utils/seedGuard.test.ts
@@ -1,0 +1,222 @@
+import {
+  assertSeedTargetIsLocal,
+  describeBlockedSeed,
+  evaluateSeedTarget,
+  isOverrideEnabled,
+  normalizeHostname,
+  SEED_OVERRIDE_ENV,
+  SeedGuardError,
+} from "./seedGuard";
+
+// A realistic PlanetScale-shaped connection string. The password is fictional;
+// the point of these tests is that the guard never reaches it.
+const REMOTE_URL =
+  "mysql://user:not-a-real-password@aws.connect.psdb.cloud/nucarpool?sslaccept=strict";
+const LOCAL_URL = "mysql://root:password@localhost:3306/nucoop";
+
+describe("normalizeHostname", () => {
+  it("strips the brackets the URL parser puts around IPv6 literals", () => {
+    expect(normalizeHostname("[::1]")).toBe("::1");
+  });
+
+  it("lowercases, since hostnames are case-insensitive", () => {
+    expect(normalizeHostname("LOCALHOST")).toBe("localhost");
+  });
+
+  it("leaves an ordinary hostname alone", () => {
+    expect(normalizeHostname("127.0.0.1")).toBe("127.0.0.1");
+  });
+
+  it("does not treat a lone bracket as an IPv6 literal", () => {
+    expect(normalizeHostname("[")).toBe("[");
+  });
+});
+
+describe("isOverrideEnabled", () => {
+  it.each(["1", "true", "TRUE", " true "])(
+    "treats %p as opting in",
+    (value) => {
+      expect(isOverrideEnabled(value)).toBe(true);
+    },
+  );
+
+  it.each([undefined, "", "0", "false", "no", "yes", "please"])(
+    "does not treat %p as opting in",
+    (value) => {
+      expect(isOverrideEnabled(value)).toBe(false);
+    },
+  );
+});
+
+describe("evaluateSeedTarget", () => {
+  it.each([
+    "mysql://root:password@localhost:3306/nucoop",
+    "mysql://root:password@127.0.0.1:3306/nucoop",
+    "mysql://root:password@[::1]:3306/nucoop",
+    "mysql://root:password@0.0.0.0:3306/nucoop",
+    "mysql://root:password@mysql:3306/nucoop",
+    "mysql://root:password@mysql-on-docker:3306/nucoop",
+    "mysql://root:password@LocalHost:3306/nucoop",
+  ])("allows the local target %p", (url) => {
+    expect(evaluateSeedTarget(url)).toEqual({
+      allowed: true,
+      hostname: expect.any(String),
+      reason: "local-host",
+    });
+  });
+
+  it("blocks a remote host", () => {
+    expect(evaluateSeedTarget(REMOTE_URL)).toEqual({
+      allowed: false,
+      hostname: "aws.connect.psdb.cloud",
+      reason: "remote-host",
+    });
+  });
+
+  // The reason the guard compares hostname only, rather than searching the
+  // connection string for "localhost".
+  it("is not fooled by a credential that looks local", () => {
+    expect(
+      evaluateSeedTarget("mysql://localhost:pw@evil.example.com/db"),
+    ).toEqual({
+      allowed: false,
+      hostname: "evil.example.com",
+      reason: "remote-host",
+    });
+  });
+
+  it("is not fooled by a query parameter that looks local", () => {
+    expect(
+      evaluateSeedTarget("mysql://u:p@evil.example.com/db?host=localhost"),
+    ).toEqual({
+      allowed: false,
+      hostname: "evil.example.com",
+      reason: "remote-host",
+    });
+  });
+
+  it("is not fooled by a hostname that merely ends in an allowed name", () => {
+    expect(evaluateSeedTarget("mysql://u:p@notlocalhost/db").allowed).toBe(
+      false,
+    );
+    expect(
+      evaluateSeedTarget("mysql://u:p@localhost.evil.example.com/db").allowed,
+    ).toBe(false);
+  });
+
+  describe("failing closed", () => {
+    it.each([undefined, "", "   "])(
+      "blocks a missing DATABASE_URL (%p)",
+      (url) => {
+        expect(evaluateSeedTarget(url)).toEqual({
+          allowed: false,
+          hostname: null,
+          reason: "missing-url",
+        });
+      },
+    );
+
+    it("blocks an unparseable DATABASE_URL", () => {
+      expect(evaluateSeedTarget("not a url")).toEqual({
+        allowed: false,
+        hostname: null,
+        reason: "unparseable-url",
+      });
+    });
+
+    it("blocks a URL with no hostname", () => {
+      expect(evaluateSeedTarget("mysql:///nucoop")).toEqual({
+        allowed: false,
+        hostname: null,
+        reason: "empty-hostname",
+      });
+    });
+
+    it("does not let the override authorise an unidentifiable target", () => {
+      expect(evaluateSeedTarget(undefined, "1").allowed).toBe(false);
+      expect(evaluateSeedTarget("not a url", "1").allowed).toBe(false);
+    });
+  });
+
+  describe("the override", () => {
+    it("permits a remote host when explicitly enabled", () => {
+      expect(evaluateSeedTarget(REMOTE_URL, "1")).toEqual({
+        allowed: true,
+        hostname: "aws.connect.psdb.cloud",
+        reason: "override",
+      });
+    });
+
+    it("still blocks when set to a value that is not an opt-in", () => {
+      expect(evaluateSeedTarget(REMOTE_URL, "0").allowed).toBe(false);
+      expect(evaluateSeedTarget(REMOTE_URL, "false").allowed).toBe(false);
+      expect(evaluateSeedTarget(REMOTE_URL, "").allowed).toBe(false);
+    });
+
+    it("is not needed for a local host, and is not reported for one", () => {
+      expect(evaluateSeedTarget(LOCAL_URL, "1").reason).toBe("local-host");
+    });
+  });
+});
+
+describe("describeBlockedSeed", () => {
+  it("names the refused host and how to override deliberately", () => {
+    const message = describeBlockedSeed(evaluateSeedTarget(REMOTE_URL));
+    expect(message).toContain("aws.connect.psdb.cloud");
+    expect(message).toContain(SEED_OVERRIDE_ENV);
+    expect(message).toContain("DELETES");
+  });
+
+  // The connection string holds credentials, so it must never be echoed.
+  it("never leaks the password from the connection string", () => {
+    const message = describeBlockedSeed(evaluateSeedTarget(REMOTE_URL));
+    expect(message).not.toContain("not-a-real-password");
+    expect(message).not.toContain(REMOTE_URL);
+  });
+
+  it("explains a missing DATABASE_URL without inventing a host", () => {
+    const message = describeBlockedSeed(evaluateSeedTarget(undefined));
+    expect(message).toContain("DATABASE_URL is not set");
+    expect(message).not.toContain(SEED_OVERRIDE_ENV);
+  });
+
+  it("refuses to describe an allowed decision", () => {
+    expect(() => describeBlockedSeed(evaluateSeedTarget(LOCAL_URL))).toThrow();
+  });
+});
+
+describe("assertSeedTargetIsLocal", () => {
+  it("returns the decision for a local target", () => {
+    expect(assertSeedTargetIsLocal({ DATABASE_URL: LOCAL_URL })).toEqual({
+      allowed: true,
+      hostname: "localhost",
+      reason: "local-host",
+    });
+  });
+
+  it("throws SeedGuardError for a remote target, carrying the reason", () => {
+    expect(() => assertSeedTargetIsLocal({ DATABASE_URL: REMOTE_URL })).toThrow(
+      SeedGuardError,
+    );
+    try {
+      assertSeedTargetIsLocal({ DATABASE_URL: REMOTE_URL });
+      throw new Error("expected assertSeedTargetIsLocal to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(SeedGuardError);
+      expect((error as SeedGuardError).reason).toBe("remote-host");
+    }
+  });
+
+  it("reads the override from the environment it is given", () => {
+    expect(
+      assertSeedTargetIsLocal({
+        DATABASE_URL: REMOTE_URL,
+        [SEED_OVERRIDE_ENV]: "1",
+      }).reason,
+    ).toBe("override");
+  });
+
+  it("throws when the environment has no DATABASE_URL at all", () => {
+    expect(() => assertSeedTargetIsLocal({})).toThrow(SeedGuardError);
+  });
+});

--- a/src/utils/seedGuard.ts
+++ b/src/utils/seedGuard.ts
@@ -1,0 +1,195 @@
+/**
+ * Safety guard for the destructive seed script.
+ *
+ * `prisma/seed.ts` deletes every row from six tables before inserting generated
+ * data, and it writes to whatever `DATABASE_URL` points at. Three commands reach
+ * it — `yarn seed`, `yarn build:preview`, and a database reset during
+ * `yarn db:schema`, because Prisma runs the configured seed command after a
+ * reset. The check therefore lives in the script itself rather than in any one
+ * command, so no invocation path can skip it.
+ *
+ * This module is deliberately dependency-free and side-effect-free so it can be
+ * unit tested without a database or a Prisma client. It is tooling, not
+ * application code — nothing under `src/pages` or `src/server` should import it.
+ */
+
+/** Environment variable that deliberately permits seeding a non-local host. */
+export const SEED_OVERRIDE_ENV = "SEED_ALLOW_REMOTE";
+
+/**
+ * Hosts the seed script may wipe. Default deny: anything absent from this set is
+ * refused. Extend this set — it is the single place the allowlist is defined.
+ *
+ * `mysql` and `mysql-on-docker` are the Compose service and container names, for
+ * a seed run issued from inside the Compose network rather than from the host.
+ */
+export const LOCAL_HOSTNAMES: ReadonlySet<string> = new Set([
+  "localhost",
+  "127.0.0.1",
+  "::1",
+  "0.0.0.0",
+  "mysql",
+  "mysql-on-docker",
+]);
+
+/** Values of {@link SEED_OVERRIDE_ENV} that count as opting in. */
+const OVERRIDE_ENABLED_VALUES: ReadonlySet<string> = new Set(["1", "true"]);
+
+export type SeedBlockReason =
+  | "missing-url"
+  | "unparseable-url"
+  | "empty-hostname"
+  | "remote-host";
+
+export type AllowedSeedTarget = {
+  allowed: true;
+  hostname: string;
+  reason: "local-host" | "override";
+};
+
+export type SeedTargetDecision =
+  | AllowedSeedTarget
+  | { allowed: false; hostname: string | null; reason: SeedBlockReason };
+
+/**
+ * The WHATWG URL parser keeps IPv6 literals bracketed (`[::1]`), and hostnames
+ * are case-insensitive, so both are normalised before the allowlist comparison.
+ */
+export function normalizeHostname(hostname: string): string {
+  const unbracketed =
+    hostname.length > 1 && hostname.startsWith("[") && hostname.endsWith("]")
+      ? hostname.slice(1, -1)
+      : hostname;
+  return unbracketed.toLowerCase();
+}
+
+/** True only for an explicit, recognised opt-in value. */
+export function isOverrideEnabled(value: string | undefined): boolean {
+  return (
+    value !== undefined &&
+    OVERRIDE_ENABLED_VALUES.has(value.trim().toLowerCase())
+  );
+}
+
+/**
+ * Decides whether the seed script may run against `databaseUrl`.
+ *
+ * Fails closed: a missing or unparseable connection string is refused rather
+ * than assumed local, and the override only ever relaxes the *remote host*
+ * decision — it cannot authorise a target we were unable to identify.
+ *
+ * Only the hostname is compared. Credentials cannot smuggle a match, because
+ * `mysql://localhost:pw@evil.example.com/db` parses to hostname
+ * `evil.example.com`, not `localhost`.
+ */
+export function evaluateSeedTarget(
+  databaseUrl: string | undefined,
+  overrideValue?: string,
+): SeedTargetDecision {
+  if (databaseUrl === undefined || databaseUrl.trim() === "") {
+    return { allowed: false, hostname: null, reason: "missing-url" };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(databaseUrl);
+  } catch {
+    return { allowed: false, hostname: null, reason: "unparseable-url" };
+  }
+
+  const hostname = normalizeHostname(parsed.hostname);
+  if (hostname === "") {
+    return { allowed: false, hostname: null, reason: "empty-hostname" };
+  }
+
+  if (LOCAL_HOSTNAMES.has(hostname)) {
+    return { allowed: true, hostname, reason: "local-host" };
+  }
+
+  if (isOverrideEnabled(overrideValue)) {
+    return { allowed: true, hostname, reason: "override" };
+  }
+
+  return { allowed: false, hostname, reason: "remote-host" };
+}
+
+/**
+ * Explains a refusal. Never includes the connection string itself, which holds
+ * credentials — only the hostname it resolved to.
+ */
+export function describeBlockedSeed(decision: SeedTargetDecision): string {
+  if (decision.allowed) {
+    throw new Error("describeBlockedSeed called with an allowed decision");
+  }
+
+  const allowed = [...LOCAL_HOSTNAMES].join(", ");
+  const consequence = [
+    "prisma/seed.ts DELETES every row from request, carpool_search, location,",
+    "group, message and user before inserting generated data. Against a shared",
+    "database this destroys real user data and is not recoverable from the app.",
+  ].join("\n");
+
+  const headline: Record<SeedBlockReason, string> = {
+    "missing-url": "DATABASE_URL is not set, so the target cannot be verified.",
+    "unparseable-url":
+      "DATABASE_URL could not be parsed as a URL, so the target cannot be verified.",
+    "empty-hostname":
+      "DATABASE_URL has no hostname, so the target cannot be verified.",
+    "remote-host": `DATABASE_URL points at the non-local host "${decision.hostname}".`,
+  };
+
+  const remedy =
+    decision.reason === "remote-host"
+      ? [
+          `Allowed hosts: ${allowed}`,
+          "",
+          "If this should have been your local Docker MySQL, correct DATABASE_URL and",
+          "re-run. If you genuinely intend to seed this host, opt in for that one",
+          `command: ${SEED_OVERRIDE_ENV}=1 yarn seed`,
+        ].join("\n")
+      : [
+          `Set DATABASE_URL to your local database before seeding. Allowed hosts: ${allowed}`,
+        ].join("\n");
+
+  return [
+    "Refusing to seed.",
+    "",
+    headline[decision.reason],
+    "",
+    consequence,
+    "",
+    remedy,
+  ].join("\n");
+}
+
+/** Thrown when the guard refuses a seed run. */
+export class SeedGuardError extends Error {
+  readonly reason: SeedBlockReason;
+
+  constructor(decision: Extract<SeedTargetDecision, { allowed: false }>) {
+    super(describeBlockedSeed(decision));
+    this.name = "SeedGuardError";
+    this.reason = decision.reason;
+  }
+}
+
+/**
+ * The slice of the environment this guard reads. Deliberately not
+ * `NodeJS.ProcessEnv`, which this repository augments with required keys that a
+ * caller (or a test) has no reason to supply.
+ */
+export type SeedEnvironment = Readonly<Record<string, string | undefined>>;
+
+/**
+ * Throws {@link SeedGuardError} unless the configured database is a local one.
+ * Call before the first destructive statement.
+ */
+export function assertSeedTargetIsLocal(
+  env: SeedEnvironment = process.env,
+): AllowedSeedTarget {
+  const decision = evaluateSeedTarget(env.DATABASE_URL, env[SEED_OVERRIDE_ENV]);
+  if (!decision.allowed) {
+    throw new SeedGuardError(decision);
+  }
+  return decision;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2722,6 +2722,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@29.5.14":
+  version "29.5.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.14.tgz#2b910912fa1d6856cadcd0c1f95af7df1d6049e5"
+  integrity sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==
+  dependencies:
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
@@ -4393,7 +4401,7 @@ exit@^0.1.2:
   resolved "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
-expect@^29.7.0:
+expect@^29.0.0, expect@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz"
   integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
@@ -6521,7 +6529,7 @@ prettier@3.6.2:
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz"
   integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
 
-pretty-format@^29.7.0:
+pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz"
   integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==


### PR DESCRIPTION
Jira: [SCRUM-212](https://carpoolnu.atlassian.net/browse/SCRUM-212)

## Why

`prisma/seed.ts` deletes every row from `request`, `carpool_search`, `location`, `group`, `message` and `user` before inserting generated data, and it writes to whatever `DATABASE_URL` points at — with **no environment check of any kind**. Pointed at PlanetScale it would destroy real user data, unrecoverably from within the app.

## What changed

**New — `src/utils/seedGuard.ts`.** A default-deny hostname allowlist, written as pure functions so it is testable without a database:

- **Hostname comparison only.** A credential cannot smuggle a match: `mysql://localhost:pw@evil.example.com/db` parses to hostname `evil.example.com`, not `localhost`. Same for `?host=localhost`.
- **Fails closed.** A missing, unparseable, or hostless `DATABASE_URL` is refused rather than assumed local, and the override cannot authorise a target that could not be identified.
- **Never echoes the connection string**, which holds credentials — only the hostname it resolved to.
- Allowed: `localhost`, `127.0.0.1`, `::1`, `0.0.0.0`, `mysql`, `mysql-on-docker`. Extend `LOCAL_HOSTNAMES`, which is the single definition.

**`prisma/seed.ts`** calls it as the first statement in `main()`, so a refusal also avoids the ~140 Mapbox geocode calls further down, and prints the guard message without a stack trace that would bury it.

**Tests — the repository's first.** 43 cases in `src/utils/seedGuard.test.ts` covering the allowlist, IPv6 bracket handling, credential and query-parameter smuggling, every fail-closed branch, override parsing, and that the message never leaks the password.

## Acceptance criteria

- **Verify and document the destructive behaviour** — done; documented in the README, which previously said only "populate the database with generated users".
- **Guard against non-local/shared databases** — done, default-deny.
- **Clear error message when blocked** — done; names the refused host, states what would be deleted, and shows the deliberate override.
- **Normal local development still works** — `localhost` and the Compose host names are allowed; unit tests cover each.
- **Review `build:preview` and other invoking commands** — done, and the ticket undercounted them. There are **three** paths, not two: `yarn seed`, `yarn build:preview`, and **`yarn db:schema`**, because Prisma runs the configured seed command automatically after `migrate dev` resets a database. That third path is part of normal setup and was documented nowhere. The guard lives inside `seed.ts` precisely so all three are covered.
- **Update developer documentation** — done: README gains a "Seeding resets your local data" section with the three-path table; `CLAUDE.md`, `docs/development/AI_DEVELOPMENT_WORKFLOW.md`, and `src/server/db/README.md` updated.
- **Add tests** — done, 43 cases.

## Decisions worth reviewing

**`build:preview` deliberately does NOT get the override.** Confirmed with the requester before implementing. It will now fail the guard if pointed at a remote database. Nothing in the repository indicates any deployment invokes it (`vercel-build` calls a `vercel.sh` that does not exist — SCRUM-249), but if something does, this breaks it *loudly* rather than silently wiping a database. Its auto-confirmed `echo "y" | prisma db push` is a separate hazard that belongs with SCRUM-249.

**`@types/jest` was added.** `jest` and `ts-jest` were installed with **no type definitions at all**, so the new tests produced 79 `tsc` errors. Without this the `tsc` check goes red. The `yarn.lock` edit is deliberately minimal — the `@types/jest` entry plus the two existing keys that needed a `^29.0.0` spec — because `yarn add` also rewrote ~500 lines of unrelated key ordering. `yarn install --frozen-lockfile` was verified against the hand-minimised lockfile.

**`--passWithNoTests` dropped from `test.yml`.** Its stated purpose was to stay green while no tests existed. With tests present, an empty run should fail rather than pass silently.

## Validation

`yarn lint`, `yarn tsc`, `yarn test` (43 passing), `yarn check:env`, `prettier --check`, and `yarn install --frozen-lockfile` all pass.

Guard decisions were also exercised directly for each scenario — remote host, unset `DATABASE_URL`, malformed `DATABASE_URL`, local host, and remote-with-override — confirming the exact message a developer sees and that the password never appears in it.

## Known limitations and risks

- **The full `yarn seed` path was not executed end to end.** Seed commands are denied in `.claude/settings.json`, and I did not work around that. The guard's logic is covered by unit tests and its decisions were demonstrated directly, but nobody has yet watched a real `yarn seed` refuse a real remote connection string. **That is worth one manual check before merging** — safest with a deliberately wrong `DATABASE_URL` host, which the guard should refuse before connecting.
- **The allowlist is hostname-based, not authoritative.** A tunnel or `/etc/hosts` entry mapping `localhost` to a remote database would pass. This raises the floor on accidents; it is not a security boundary against deliberate misuse.
- **`SEED_ALLOW_REMOTE=1` is a real footgun by design.** It exists so a legitimate remote reseed does not require a code change. Documentation states plainly what it destroys.
- **Formatting churn in `prisma/seed.ts`.** The file was already unformatted, so the pre-commit hook (`pretty-quick --staged`) reformatted it. Roughly 30 of its changed lines are mine; the rest is quote style, wrapping, and a missing trailing newline. Reviewing with whitespace changes hidden will help.
- `.claude/skills/jira-ticket/SKILL.md` is touched because it asserted "there is currently no test suite" — now false.

## Not included

`clearConnections()` at `seed.ts:312` is redundant with the `deleteAllData()` call on the next line, and `timeEnd`/`addFavorites` are unused. Left alone to keep this diff about the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)