### PR TITLE
SCRUM-256: seed conversations and messages, and stop consuming Mapbox quota

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Test coverage is narrow but no longer empty: [`src/utils/seedGuard.test.ts`](src
 
 **Database — these commands destroy data**
 
-- `yarn seed` **wipes the database first**. [`prisma/seed.ts`](prisma/seed.ts) deletes every row from `request`, `carpool_search`, `location`, `group`, `message`, and `user`, then inserts ~70 generated users. It also makes ~140 Mapbox reverse-geocode calls.
+- `yarn seed` **wipes the database first**. [`prisma/seed.ts`](prisma/seed.ts) deletes every row from `request`, `message`, `conversation`, `carpool_search`, `location`, `group`, and `user`, then inserts ~70 generated users, each with a request, a conversation and two messages. Addresses are synthesised offline, so it makes **no** Mapbox calls unless `SEED_REVERSE_GEOCODE=1` is set — see [`src/utils/seedAddresses.ts`](src/utils/seedAddresses.ts).
 - [`src/utils/seedGuard.ts`](src/utils/seedGuard.ts) refuses to seed a non-local host, fails closed on a missing or unparseable `DATABASE_URL`, and covers all three seed paths because it runs inside `seed.ts` itself. `SEED_ALLOW_REMOTE=1` overrides it. **The guard does not relax any rule here** — seed commands remain denied in [`.claude/settings.json`](.claude/settings.json), and the override must never be set to make something work.
 - `yarn build:preview` runs `prisma db push` auto-confirmed with `echo "y"` **and then re-seeds**. It can force-alter a schema and wipe data — never run it to "test the build"; use `yarn build`.
 - `yarn db:schema` runs `prisma migrate dev`, which writes migrations and may prompt to reset the local database on drift. **If it resets, Prisma runs the seed script automatically** — so this command can wipe and regenerate data without `yarn seed` being typed. Opt out with `npx prisma migrate dev --skip-seed`; appending the flag to `yarn db:schema` does not work, because yarn passes it to `prisma generate` instead.
@@ -47,7 +47,7 @@ Test coverage is narrow but no longer empty: [`src/utils/seedGuard.test.ts`](src
 
 - `user.email.*` procedures send **real mail** through AWS SES.
 - `user.message.sendMessage` fires **real Pusher events** on `conversation-{requestId}` and `notification-{toUserId}`.
-- `mapbox.*` procedures, [`src/utils/map/geocode.ts`](src/utils/map/geocode.ts), and the seed script consume Mapbox API quota.
+- `mapbox.*` procedures and [`src/utils/map/geocode.ts`](src/utils/map/geocode.ts) consume Mapbox API quota. The seed script does not, unless `SEED_REVERSE_GEOCODE=1` opts in.
 - [`scripts/emailtemplate.py`](scripts/emailtemplate.py) is active infrastructure — it creates/updates the SES templates the app sends. Running it mutates templates in the configured AWS account.
 - Verify which environment your credentials point at before triggering any of these. Do not exercise them against shared or production resources.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ On Apple Silicon the container now runs natively rather than under x86 emulation
 
 ### Seeding resets your local data
 
-`yarn seed` is **not additive**. Before inserting anything, [`prisma/seed.ts`](prisma/seed.ts) deletes every row from `request`, `carpool_search`, `location`, `group`, `message` and `user`, then inserts about 70 generated users with fixed ids and 10 groups. It also makes roughly 140 Mapbox reverse-geocode calls, which consume API quota.
+`yarn seed` is **not additive**. Before inserting anything, [`prisma/seed.ts`](prisma/seed.ts) deletes every row from `request`, `message`, `conversation`, `carpool_search`, `location`, `group` and `user`, then inserts about 70 generated users with fixed ids, 10 groups, and one request per user — each request with a conversation and a short two-sided message thread, so the messaging UI has something to render.
+
+Addresses are synthesised offline and deterministically, so seeding makes **no network calls and consumes no Mapbox quota**. Set `SEED_REVERSE_GEOCODE=1` to reverse geocode against Mapbox instead; results are cached per coordinate, and any failure falls back to a synthesised address.
 
 Three commands reach that script, not one:
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,154 +1,122 @@
 import { CarpoolGroup, PrismaClient, Role, User } from "@prisma/client";
 import { range } from "lodash";
 import Random from "random-seed";
-import { generateUser, GenerateUserInput } from "../src/utils/recommendation";
+import { generateUser } from "../src/utils/recommendation";
 import { timeEnd } from "console";
 import {
   assertSeedTargetIsLocal,
   SEED_OVERRIDE_ENV,
   SeedGuardError,
 } from "../src/utils/seedGuard";
+import {
+  AddressResolver,
+  createAddressResolver,
+} from "../src/utils/seedAddresses";
 
 const prisma = new PrismaClient();
 
-async function reverseGeocode(
-  lng: number,
-  lat: number,
-): Promise<{
-  street: string;
-  city: string;
-  state: string;
-  address: string;
-}> {
-  const mapboxToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
-
-  try {
-    const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${lng},${lat}.json?access_token=${mapboxToken}&types=address,place,locality,region`;
-    const response = await fetch(url);
-    const data = await response.json();
-
-    let street = "";
-    let city = "";
-    let state = "";
-    let address = "";
-    let buildingNumber = "";
-
-    // Try to extract address components from the response
-    for (const feature of data.features) {
-      // Look for address features to get street and building number
-      if (feature.place_type.includes("address")) {
-        // Try to extract building/house number from address text
-        const addressParts = feature.text.split(" ");
-        // Check if there exists a building number
-        if (addressParts.length > 0 && !isNaN(Number(addressParts[0]))) {
-          buildingNumber = addressParts[0];
-          street = addressParts.slice(1).join(" ");
-        } else {
-          street = feature.text;
-        }
-      }
-
-      // Look for place features to get city name
-      if (feature.place_type.includes("place") && !city) {
-        city = feature.text;
-      }
-
-      // Look for region features to get state name
-      if (feature.place_type.includes("region") && !state) {
-        state = feature.text;
-      }
-
-      // Prefer POI names for the address field if available
-      if (feature.place_type.includes("poi") && !address) {
-        address = feature.text;
-      }
-    }
-
-    // Append building number to street if it exists
-    if (buildingNumber && street) {
-      street = `${buildingNumber} ${street}`;
-    }
-
-    // If no address was found, create one from the components
-    if (!address) {
-      address = `${street}, ${city}, ${state}`;
-    }
-
-    return { street, city, state, address };
-  } catch (error) {
-    console.error("Reverse geocoding failed:", error);
-    return {
-      street: "123 Main St",
-      city: "Boston",
-      state: "MA",
-      address: "123 Main St, Boston, MA",
-    };
-  }
-}
+/**
+ * Every table the seed writes to, in an order safe to delete in: rows that
+ * reference another table go first.
+ *
+ * `conversation` is included because it was previously missed. Under
+ * `relationMode = "prisma"` there is no database-level foreign key, so orphaned
+ * conversations simply survived a re-seed pointing at deleted requests — and
+ * since `Conversation.requestId` is `@unique`, a later request reusing an id
+ * would collide with one of those ghosts.
+ */
+export const SEED_DELETE_ORDER = [
+  "request",
+  "message",
+  "conversation",
+  "carpoolSearch",
+  "location",
+  "carpoolGroup",
+  "user",
+] as const;
 
 /**
- * Deletes all entries in the user table.
+ * Deletes every row the seed is responsible for.
+ *
+ * This replaces the previous `clearConnections()` pass, which ran immediately
+ * before this and issued roughly 4,900 no-op `favorites.disconnect` writes
+ * against rows that were about to be deleted anyway.
  */
-const deleteAllData = async () => {
+export const deleteAllData = async () => {
   await prisma.request.deleteMany({});
+  await prisma.message.deleteMany({});
+  await prisma.conversation.deleteMany({});
   await prisma.carpoolSearch.deleteMany({});
   await prisma.location.deleteMany({});
   await prisma.carpoolGroup.deleteMany({});
-  await prisma.message.deleteMany({});
   await prisma.user.deleteMany({});
 };
 
 /**
- * Clears connections between users.
+ * Creates one request together with the conversation and messages the
+ * application would have created alongside it.
+ *
+ * Mirrors `requests.create` in `src/server/router/user/requests.ts`: the request
+ * carries an empty `message` column, the conversation is keyed by `requestId`,
+ * the request is then back-linked through `conversationId`, and the greeting
+ * lives in a `Message` row rather than on the request.
+ *
+ * A reply from the recipient is added as well, left unread, so the messaging UI
+ * has a two-sided thread and an unread indicator to render locally.
  */
-const clearConnections = async () => {
-  const users = await prisma.user.findMany();
+export const seedRequestWithConversation = async (
+  fromUserId: string,
+  toUserId: string,
+) => {
+  const request = await prisma.request.create({
+    data: {
+      message: "",
+      fromUser: { connect: { id: fromUserId } },
+      toUser: { connect: { id: toUserId } },
+    },
+  });
 
-  await Promise.all(
-    users.map((user) =>
-      prisma.request.deleteMany({
-        where: {
-          OR: [{ fromUserId: user.id }, { toUserId: user.id }],
-        },
-      }),
-    ),
-  );
+  const conversation = await prisma.conversation.create({
+    data: { requestId: request.id },
+  });
 
-  await Promise.all(
-    users.map((user) =>
-      prisma.user.update({
-        where: {
-          id: user.id,
-        },
-        data: {
-          favorites: {
-            disconnect: new Array(70)
-              .fill(undefined)
-              .map((_, idx) => ({ id: `${idx}` })),
-          },
-        },
-      }),
-    ),
-  );
+  await prisma.request.update({
+    where: { id: request.id },
+    data: { conversationId: conversation.id },
+  });
+
+  await prisma.message.create({
+    data: {
+      conversationId: conversation.id,
+      userId: fromUserId,
+      content: `Hi! I saw we have similar commutes — want to carpool?`,
+      isRead: true,
+    },
+  });
+
+  await prisma.message.create({
+    data: {
+      conversationId: conversation.id,
+      userId: toUserId,
+      content: `Sounds good, what time do you usually leave?`,
+      isRead: false,
+    },
+  });
+
+  return { requestId: request.id, conversationId: conversation.id };
 };
 
 /**
- * Generates requests between users in our database.
+ * Generates requests between users in our database, each with a conversation
+ * and messages so the messaging feature is exercisable against seeded data.
  */
 const generateRequests = async (userIds: string[]) => {
   await Promise.all(
     userIds.map((_, idx) =>
-      prisma.request.create({
-        data: {
-          message: "Hello",
-          fromUser: {
-            connect: { id: idx.toString() },
-          },
-          toUser: {
-            connect: { id: pickConnection(idx, userIds.length) },
-          },
-        },
-      }),
+      seedRequestWithConversation(
+        idx.toString(),
+        pickConnection(idx, userIds.length),
+      ),
     ),
   );
 };
@@ -268,47 +236,59 @@ type GeneratedUserData = {
 /**
  * Creates users and adds them to the database.
  */
-const createUserData = async () => {
+const createUserData = async (resolveAddress: AddressResolver) => {
   // updated function to handle async getRandomUsers
   const userGroups = await Promise.all([
-    genRandomUsers({
-      // MISSION HILL => DOWNTOWN
-      startCoordLat: 42.33,
-      startCoordLng: -71.1,
-      companyCoordLat: 42.35,
-      companyCoordLng: -71.06,
-      count: 30,
-      seed: "sjafdlsdjfjadljflasjkfdl;",
-    }),
-    genRandomUsers({
-      // CAMPUS => WALTHAM
-      startCoordLat: 42.34,
-      startCoordLng: -71.09,
-      companyCoordLat: 42.4,
-      companyCoordLng: -71.26,
-      count: 10,
-      seed: "kajshdkfjhasdkjfhla",
-    }),
-    genRandomUsers({
-      // MISSION HILL => CAMBRIDGE
-      startCoordLat: 42.32,
-      startCoordLng: -71.095,
-      companyCoordLat: 42.37,
-      companyCoordLng: -71.1,
-      count: 15,
-      seed: "asjfwieoiroqweiaof",
-      timezone: "UTC",
-    }),
-    genRandomUsers({
-      // BROOKLINE => FENWAY
-      startCoordLat: 42.346,
-      startCoordLng: -71.127,
-      companyCoordLat: 42.344,
-      companyCoordLng: -71.1,
-      count: 15,
-      seed: "dfsiuyisryrklewuoiadusruasi",
-      timezone: "UTC",
-    }),
+    genRandomUsers(
+      {
+        // MISSION HILL => DOWNTOWN
+        startCoordLat: 42.33,
+        startCoordLng: -71.1,
+        companyCoordLat: 42.35,
+        companyCoordLng: -71.06,
+        count: 30,
+        seed: "sjafdlsdjfjadljflasjkfdl;",
+      },
+      resolveAddress,
+    ),
+    genRandomUsers(
+      {
+        // CAMPUS => WALTHAM
+        startCoordLat: 42.34,
+        startCoordLng: -71.09,
+        companyCoordLat: 42.4,
+        companyCoordLng: -71.26,
+        count: 10,
+        seed: "kajshdkfjhasdkjfhla",
+      },
+      resolveAddress,
+    ),
+    genRandomUsers(
+      {
+        // MISSION HILL => CAMBRIDGE
+        startCoordLat: 42.32,
+        startCoordLng: -71.095,
+        companyCoordLat: 42.37,
+        companyCoordLng: -71.1,
+        count: 15,
+        seed: "asjfwieoiroqweiaof",
+        timezone: "UTC",
+      },
+      resolveAddress,
+    ),
+    genRandomUsers(
+      {
+        // BROOKLINE => FENWAY
+        startCoordLat: 42.346,
+        startCoordLng: -71.127,
+        companyCoordLat: 42.344,
+        companyCoordLng: -71.1,
+        count: 15,
+        seed: "dfsiuyisryrklewuoiadusruasi",
+        timezone: "UTC",
+      },
+      resolveAddress,
+    ),
   ]);
 
   const usersData: GeneratedUserData[] = userGroups
@@ -318,15 +298,12 @@ const createUserData = async () => {
       ...user,
     }));
 
-  await clearConnections();
   await deleteAllData();
 
   // Create users with only non-migrated fields
   await Promise.all(
     usersData.map((userData) =>
-      prisma.user.upsert(
-        generateUser({ id: userData.id } as GenerateUserInput & { id: string }),
-      ),
+      prisma.user.upsert(generateUser({ id: userData.id })),
     ),
   );
 
@@ -431,9 +408,12 @@ const createUserData = async () => {
         },
       });
     } catch (error) {
-      console.error(
-        `Failed to create CarpoolSearch for user ${userData.id}:`,
-        error,
+      // Fail the whole run. This used to log and continue, so a partially
+      // seeded database — some users with no location or carpool search —
+      // looked like a successful seed.
+      throw new Error(
+        `Failed to seed location and carpool search for user ${userData.id}`,
+        { cause: error },
       );
     }
   }
@@ -446,27 +426,31 @@ const createUserData = async () => {
  *               including the start/end coordinates to congregate data
  *               around, the offset of that congregation (how spread should
  *               the points be), the num of outputs, and a random seed.
- * @returns An array of size "count" with GenerateUserInput examples.
+ * @param resolveAddress resolves a coordinate to a street address
+ * @returns An array of size "count" of generated user data, without ids.
  */
-const genRandomUsers = async ({
-  startCoordLat,
-  startCoordLng,
-  companyCoordLat,
-  companyCoordLng,
-  coordOffset = 0.03,
-  count,
-  seed,
-  timezone,
-}: {
-  startCoordLat: number;
-  startCoordLng: number;
-  companyCoordLat: number;
-  companyCoordLng: number;
-  coordOffset?: number;
-  count: number;
-  seed?: string;
-  timezone?: string;
-}): Promise<any[]> => {
+const genRandomUsers = async (
+  {
+    startCoordLat,
+    startCoordLng,
+    companyCoordLat,
+    companyCoordLng,
+    coordOffset = 0.03,
+    count,
+    seed,
+    timezone,
+  }: {
+    startCoordLat: number;
+    startCoordLng: number;
+    companyCoordLat: number;
+    companyCoordLng: number;
+    coordOffset?: number;
+    count: number;
+    seed?: string;
+    timezone?: string;
+  },
+  resolveAddress: AddressResolver,
+): Promise<Omit<GeneratedUserData, "id">[]> => {
   const random = Random.create(seed);
   const doubleOffset = coordOffset * 2;
   const rand = (max: number) => max * random.random();
@@ -488,10 +472,11 @@ const genRandomUsers = async ({
     const userCompanyLat = companyCoordLat - coordOffset + rand(doubleOffset);
     const userCompanyLng = companyCoordLng - coordOffset + rand(doubleOffset);
 
-    // Reverse geocode to get structured address data
+    // Resolve structured address data. Offline and free unless
+    // SEED_REVERSE_GEOCODE opts into Mapbox — see src/utils/seedAddresses.ts.
     const [startAddress, companyAddress] = await Promise.all([
-      reverseGeocode(userStartLng, userStartLat),
-      reverseGeocode(userCompanyLng, userCompanyLat),
+      resolveAddress(userStartLng, userStartLat),
+      resolveAddress(userCompanyLng, userCompanyLat),
     ]);
 
     const output = {
@@ -558,10 +543,10 @@ const addFavorites = async (userId: string, ids: string[]) => {
  * Populates our database with fake data.
  */
 const main = async () => {
-  // First statement in the script. createUserData() wipes six tables, and it is
-  // reached by `yarn seed`, by `yarn build:preview`, and by a database reset
-  // during `yarn db:schema`. Refuse anything that is not a local database before
-  // doing any work — this also avoids the ~140 Mapbox geocode calls further down.
+  // First statement in the script. createUserData() wipes every table in
+  // SEED_DELETE_ORDER, and it is reached by `yarn seed`, by `yarn build:preview`,
+  // and by a database reset during `yarn db:schema`. Refuse anything that is not
+  // a local database before doing any work.
   const target = assertSeedTargetIsLocal();
 
   if (target.reason === "override") {
@@ -574,20 +559,25 @@ const main = async () => {
     );
   }
 
-  await createUserData();
+  await createUserData(createAddressResolver());
 };
 
-main()
-  .catch((e) => {
-    // A guard refusal is an expected, self-explanatory message rather than a
-    // crash, so print it without a stack trace that would bury the reason.
-    if (e instanceof SeedGuardError) {
-      console.error(e.message);
-    } else {
-      console.error(e);
-    }
-    process.exit(1);
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-  });
+// Only run when executed as a script (`prisma db seed` runs `ts-node
+// prisma/seed.ts`). Guarding this keeps the module importable, so the helpers
+// above can be exercised by tests without seeding anything.
+if (require.main === module) {
+  main()
+    .catch((e) => {
+      // A guard refusal is an expected, self-explanatory message rather than a
+      // crash, so print it without a stack trace that would bury the reason.
+      if (e instanceof SeedGuardError) {
+        console.error(e.message);
+      } else {
+        console.error(e);
+      }
+      process.exit(1);
+    })
+    .finally(async () => {
+      await prisma.$disconnect();
+    });
+}

--- a/src/utils/recommendation.ts
+++ b/src/utils/recommendation.ts
@@ -72,7 +72,9 @@ type CarpoolSearchWithLocations = CarpoolSearch & {
 /**
  * Converts a CarpoolSearch to the CommonUser interface for scoring
  */
-const carpoolSearchToCommonUser = (search: CarpoolSearchWithLocations): CommonUser => {
+const carpoolSearchToCommonUser = (
+  search: CarpoolSearchWithLocations,
+): CommonUser => {
   return {
     id: search.user.id,
     role: search.role,
@@ -121,7 +123,7 @@ export const calculateScore = (
 
   return (userSearch: CarpoolSearchWithLocations) => {
     const user = carpoolSearchToCommonUser(userSearch);
-    
+
     if (
       (currentUser.role === "RIDER" &&
         (user.role === "RIDER" || user.seatAvail === 0)) ||
@@ -307,14 +309,18 @@ export type GenerateUserInput = {
 };
 
 /**
- * Creates a full user object from a skeleton of critical user information
+ * Creates a full user object from a user id.
  *
- * @param userInfo an object containing user info that we want to switch up between users
- * @returns a full user object to insert into the database, with some fields hardcoded due to lack of significance
+ * Only the id is needed: since the migration that moved role, schedule, seats
+ * and coordinates off `User` and onto `CarpoolSearch`, everything else on the
+ * user row is either derived from the id or hardcoded. The parameter used to be
+ * typed `GenerateUserInput & { id: string }`, which forced every caller into a
+ * cast to supply fields this function never read.
+ *
+ * @param userInfo an object carrying the id to build the user around
+ * @returns an upsert argument for the user row
  */
-export const generateUser = ({
-  id,
-}: GenerateUserInput & { id: string }) => {
+export const generateUser = ({ id }: { id: string }) => {
   const updated_obj = {
     id: id,
     name: `User ${id}`,

--- a/src/utils/seedAddresses.test.ts
+++ b/src/utils/seedAddresses.test.ts
@@ -1,0 +1,260 @@
+import {
+  createAddressResolver,
+  isRealGeocodingEnabled,
+  MapboxFeature,
+  parseMapboxFeatures,
+  SEED_GEOCODE_ENV,
+  synthesizeAddress,
+} from "./seedAddresses";
+
+const silent = () => undefined;
+
+describe("synthesizeAddress", () => {
+  it("is deterministic, so re-seeding reproduces the same addresses", () => {
+    expect(synthesizeAddress(-71.1, 42.33)).toEqual(
+      synthesizeAddress(-71.1, 42.33),
+    );
+  });
+
+  it("produces a street, a Massachusetts city, and a combined address", () => {
+    const address = synthesizeAddress(-71.1, 42.33);
+    expect(address.street).toMatch(/^\d+ .+/);
+    expect(address.city).not.toBe("");
+    expect(address.state).toBe("MA");
+    expect(address.address).toBe(`${address.street}, ${address.city}, MA`);
+  });
+
+  // The old code fell back to one hardcoded address for every user whenever
+  // geocoding failed, which it always did without a Mapbox token.
+  it("varies across nearby coordinates instead of collapsing onto one address", () => {
+    const addresses = new Set<string>();
+    for (let i = 0; i < 60; i++) {
+      addresses.add(
+        synthesizeAddress(-71.1 + i * 0.001, 42.33 + i * 0.001).address,
+      );
+    }
+    expect(addresses.size).toBeGreaterThan(20);
+  });
+
+  it("distinguishes coordinates that differ within its precision", () => {
+    expect(synthesizeAddress(-71.1, 42.33)).not.toEqual(
+      synthesizeAddress(-71.10001, 42.33),
+    );
+  });
+});
+
+describe("isRealGeocodingEnabled", () => {
+  it.each(["1", "true", "TRUE", " 1 "])("treats %p as opting in", (value) => {
+    expect(isRealGeocodingEnabled(value)).toBe(true);
+  });
+
+  it.each([undefined, "", "0", "false", "yes"])(
+    "does not treat %p as opting in",
+    (value) => {
+      expect(isRealGeocodingEnabled(value)).toBe(false);
+    },
+  );
+});
+
+describe("parseMapboxFeatures", () => {
+  it("splits a leading building number off the address feature", () => {
+    const features: MapboxFeature[] = [
+      { place_type: ["address"], text: "360 Huntington Ave" },
+      { place_type: ["place"], text: "Boston" },
+      { place_type: ["region"], text: "Massachusetts" },
+    ];
+    expect(parseMapboxFeatures(features)).toEqual({
+      street: "360 Huntington Ave",
+      city: "Boston",
+      state: "Massachusetts",
+      address: "360 Huntington Ave, Boston, Massachusetts",
+    });
+  });
+
+  it("keeps the text intact when it does not start with a number", () => {
+    const features: MapboxFeature[] = [
+      { place_type: ["address"], text: "Huntington Ave" },
+    ];
+    expect(parseMapboxFeatures(features).street).toBe("Huntington Ave");
+  });
+
+  it("prefers a point of interest for the display address", () => {
+    const features: MapboxFeature[] = [
+      { place_type: ["address"], text: "360 Huntington Ave" },
+      { place_type: ["place"], text: "Boston" },
+      { place_type: ["poi"], text: "Northeastern University" },
+    ];
+    expect(parseMapboxFeatures(features).address).toBe(
+      "Northeastern University",
+    );
+  });
+
+  it("takes the first place and region and ignores later ones", () => {
+    const features: MapboxFeature[] = [
+      { place_type: ["place"], text: "Boston" },
+      { place_type: ["place"], text: "Cambridge" },
+      { place_type: ["region"], text: "Massachusetts" },
+      { place_type: ["region"], text: "New York" },
+    ];
+    const parsed = parseMapboxFeatures(features);
+    expect(parsed.city).toBe("Boston");
+    expect(parsed.state).toBe("Massachusetts");
+  });
+
+  it("tolerates an empty feature list and malformed features", () => {
+    expect(parseMapboxFeatures([])).toEqual({
+      street: "",
+      city: "",
+      state: "",
+      address: ", , ",
+    });
+    expect(() => parseMapboxFeatures([{}])).not.toThrow();
+  });
+});
+
+describe("createAddressResolver", () => {
+  it("never touches the network by default", async () => {
+    const fetchImpl = jest.fn();
+    const resolve = createAddressResolver({
+      env: {},
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      onNotice: silent,
+    });
+
+    const address = await resolve(-71.1, 42.33);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(address).toEqual(synthesizeAddress(-71.1, 42.33));
+  });
+
+  it("stays offline when opted in without a Mapbox token", async () => {
+    const fetchImpl = jest.fn();
+    const resolve = createAddressResolver({
+      env: { [SEED_GEOCODE_ENV]: "1" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      onNotice: silent,
+    });
+
+    await resolve(-71.1, 42.33);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("says which mode it is in, so the operator is not guessing", () => {
+    const notices: string[] = [];
+    createAddressResolver({ env: {}, onNotice: (m) => notices.push(m) });
+    expect(notices.join(" ")).toContain(SEED_GEOCODE_ENV);
+  });
+
+  describe("when geocoding is enabled with a token", () => {
+    const env = {
+      [SEED_GEOCODE_ENV]: "1",
+      NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN: "not-a-real-token",
+    };
+
+    const okResponse = () =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          features: [
+            { place_type: ["address"], text: "360 Huntington Ave" },
+            { place_type: ["place"], text: "Boston" },
+            { place_type: ["region"], text: "Massachusetts" },
+          ],
+        }),
+      }) as unknown as Response;
+
+    it("uses the geocoded result", async () => {
+      const fetchImpl = jest.fn(async () => okResponse());
+      const resolve = createAddressResolver({
+        env,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        onNotice: silent,
+      });
+
+      expect((await resolve(-71.1, 42.33)).city).toBe("Boston");
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+
+    it("caches per coordinate, so a repeated coordinate costs no quota", async () => {
+      const fetchImpl = jest.fn(async () => okResponse());
+      const resolve = createAddressResolver({
+        env,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        onNotice: silent,
+      });
+
+      await Promise.all([
+        resolve(-71.1, 42.33),
+        resolve(-71.1, 42.33),
+        resolve(-71.1, 42.33),
+      ]);
+
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+
+    it("still issues one request per distinct coordinate", async () => {
+      const fetchImpl = jest.fn(async () => okResponse());
+      const resolve = createAddressResolver({
+        env,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        onNotice: silent,
+      });
+
+      await Promise.all([resolve(-71.1, 42.33), resolve(-71.2, 42.34)]);
+
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    });
+
+    // Previously an HTTP error produced `data.features === undefined`, threw,
+    // and returned the same hardcoded address for every caller.
+    it("synthesises on a non-ok response rather than reusing one address", async () => {
+      const consoleError = jest
+        .spyOn(console, "error")
+        .mockImplementation(silent);
+      const fetchImpl = jest.fn(
+        async () =>
+          ({
+            ok: false,
+            status: 401,
+            json: async () => ({}),
+          }) as unknown as Response,
+      );
+      const resolve = createAddressResolver({
+        env,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        onNotice: silent,
+      });
+
+      const [a, b] = await Promise.all([
+        resolve(-71.1, 42.33),
+        resolve(-71.2, 42.34),
+      ]);
+
+      expect(a).toEqual(synthesizeAddress(-71.1, 42.33));
+      expect(b).toEqual(synthesizeAddress(-71.2, 42.34));
+      expect(a.address).not.toBe(b.address);
+      consoleError.mockRestore();
+    });
+
+    it("synthesises when the request rejects outright", async () => {
+      const consoleError = jest
+        .spyOn(console, "error")
+        .mockImplementation(silent);
+      const fetchImpl = jest.fn(async () => {
+        throw new Error("network down");
+      });
+      const resolve = createAddressResolver({
+        env,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        onNotice: silent,
+      });
+
+      expect(await resolve(-71.1, 42.33)).toEqual(
+        synthesizeAddress(-71.1, 42.33),
+      );
+      consoleError.mockRestore();
+    });
+  });
+});

--- a/src/utils/seedAddresses.ts
+++ b/src/utils/seedAddresses.ts
@@ -1,0 +1,234 @@
+/**
+ * Address generation for `prisma/seed.ts`.
+ *
+ * The seed needs a street/city/state for two locations per user. It used to call
+ * Mapbox reverse geocoding for every one of them — roughly 140 requests per seed,
+ * against a shared API quota, on a script whose whole purpose is throwaway local
+ * data. Worse, without `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` every one of those calls
+ * failed and fell back to the same hardcoded "123 Main St, Boston, MA", so all 70
+ * users ended up at one address.
+ *
+ * Addresses are therefore synthesised offline by default: deterministic, varied,
+ * instant, and free. Real reverse geocoding is still available by setting
+ * SEED_REVERSE_GEOCODE=1, in which case results are cached per coordinate.
+ *
+ * This module is tooling for the seed script, not application code.
+ */
+
+/** Set to "1" or "true" to reverse geocode against Mapbox instead of synthesising. */
+export const SEED_GEOCODE_ENV = "SEED_REVERSE_GEOCODE";
+
+export type SeedAddress = {
+  street: string;
+  city: string;
+  state: string;
+  address: string;
+};
+
+/**
+ * Shape of the Mapbox geocoding features this code reads. Only the fields used
+ * are declared; the API returns considerably more.
+ */
+export type MapboxFeature = {
+  place_type?: string[];
+  text?: string;
+};
+
+/** Plausible Boston-area values. The seed's coordinates are all around Boston. */
+const STREETS = [
+  "Beacon St",
+  "Boylston St",
+  "Huntington Ave",
+  "Commonwealth Ave",
+  "Massachusetts Ave",
+  "Tremont St",
+  "Columbus Ave",
+  "Harvard St",
+  "Washington St",
+  "Summer St",
+];
+
+const CITIES = [
+  "Boston",
+  "Cambridge",
+  "Brookline",
+  "Somerville",
+  "Medford",
+  "Quincy",
+  "Newton",
+  "Malden",
+];
+
+const STATE = "MA";
+
+/**
+ * FNV-1a over the coordinate at fixed precision. Any stable hash would do; the
+ * requirement is only that the same coordinate always yields the same address,
+ * so re-seeding is reproducible and location de-duplication behaves consistently.
+ */
+function hashCoordinate(lng: number, lat: number): number {
+  const key = `${lng.toFixed(5)},${lat.toFixed(5)}`;
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < key.length; i++) {
+    hash ^= key.charCodeAt(i);
+    // >>> 0 keeps this an unsigned 32-bit multiply rather than drifting into
+    // floating point, which would make the hash platform-sensitive.
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash;
+}
+
+/** A deterministic, offline, plausible address for a coordinate. */
+export function synthesizeAddress(lng: number, lat: number): SeedAddress {
+  const hash = hashCoordinate(lng, lat);
+  const street = `${(hash % 400) + 1} ${STREETS[hash % STREETS.length]}`;
+  const city = CITIES[Math.floor(hash / STREETS.length) % CITIES.length];
+  return {
+    street,
+    city,
+    state: STATE,
+    address: `${street}, ${city}, ${STATE}`,
+  };
+}
+
+/** True only for an explicit opt-in value. */
+export function isRealGeocodingEnabled(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true";
+}
+
+/**
+ * Extracts street, city and state from Mapbox geocoding features.
+ *
+ * Preserved from the original inline implementation, including its quirks: the
+ * building number is split off the `address` feature's text when the first token
+ * is numeric, and a point of interest supplies the display address when present.
+ * Extracted so it can be tested without issuing a request.
+ */
+export function parseMapboxFeatures(features: MapboxFeature[]): SeedAddress {
+  let street = "";
+  let city = "";
+  let state = "";
+  let address = "";
+  let buildingNumber = "";
+
+  for (const feature of features) {
+    const placeTypes = feature.place_type ?? [];
+    const text = feature.text ?? "";
+
+    if (placeTypes.includes("address")) {
+      const addressParts = text.split(" ");
+      if (
+        addressParts.length > 0 &&
+        addressParts[0] !== "" &&
+        !isNaN(Number(addressParts[0]))
+      ) {
+        buildingNumber = addressParts[0];
+        street = addressParts.slice(1).join(" ");
+      } else {
+        street = text;
+      }
+    }
+
+    if (placeTypes.includes("place") && !city) {
+      city = text;
+    }
+
+    if (placeTypes.includes("region") && !state) {
+      state = text;
+    }
+
+    if (placeTypes.includes("poi") && !address) {
+      address = text;
+    }
+  }
+
+  if (buildingNumber && street) {
+    street = `${buildingNumber} ${street}`;
+  }
+
+  if (!address) {
+    address = `${street}, ${city}, ${state}`;
+  }
+
+  return { street, city, state, address };
+}
+
+export type AddressResolver = (
+  lng: number,
+  lat: number,
+) => Promise<SeedAddress>;
+
+type ResolverOptions = {
+  env?: Readonly<Record<string, string | undefined>>;
+  fetchImpl?: typeof fetch;
+  onNotice?: (message: string) => void;
+};
+
+/**
+ * Builds the resolver the seed uses.
+ *
+ * Offline synthesis unless SEED_REVERSE_GEOCODE opts in and a Mapbox token is
+ * present. When geocoding is live, identical coordinates are resolved once and
+ * cached, and any failure degrades to synthesis rather than to a single shared
+ * fallback address.
+ */
+export function createAddressResolver(
+  options: ResolverOptions = {},
+): AddressResolver {
+  const env = options.env ?? process.env;
+  const notify =
+    options.onNotice ?? ((message: string) => console.log(message));
+  const token = env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+  const wantsGeocoding = isRealGeocodingEnabled(env[SEED_GEOCODE_ENV]);
+
+  if (!wantsGeocoding) {
+    notify(
+      `Synthesising addresses offline. Set ${SEED_GEOCODE_ENV}=1 to reverse geocode with Mapbox instead (consumes API quota).`,
+    );
+    return async (lng, lat) => synthesizeAddress(lng, lat);
+  }
+
+  if (!token) {
+    notify(
+      `${SEED_GEOCODE_ENV} is set but NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN is not. Synthesising addresses offline instead.`,
+    );
+    return async (lng, lat) => synthesizeAddress(lng, lat);
+  }
+
+  const doFetch = options.fetchImpl ?? fetch;
+  const cache = new Map<string, Promise<SeedAddress>>();
+  notify(
+    `${SEED_GEOCODE_ENV} is set. Reverse geocoding with Mapbox; this consumes API quota.`,
+  );
+
+  return (lng, lat) => {
+    const key = `${lng.toFixed(5)},${lat.toFixed(5)}`;
+    const cached = cache.get(key);
+    if (cached) return cached;
+
+    const pending = (async (): Promise<SeedAddress> => {
+      try {
+        const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${lng},${lat}.json?access_token=${token}&types=address,place,locality,region`;
+        const response = await doFetch(url);
+        if (!response.ok) {
+          throw new Error(`Mapbox responded ${response.status}`);
+        }
+        const data: { features?: MapboxFeature[] } = await response.json();
+        return parseMapboxFeatures(data.features ?? []);
+      } catch (error) {
+        // Synthesise rather than reuse one hardcoded address, so a partial
+        // outage does not collapse every user onto the same street.
+        console.error(
+          `Reverse geocoding failed for ${key}; synthesising instead:`,
+          error,
+        );
+        return synthesizeAddress(lng, lat);
+      }
+    })();
+
+    cache.set(key, pending);
+    return pending;
+  };
+}


### PR DESCRIPTION
Jira: [SCRUM-256](https://carpoolnu.atlassian.net/browse/SCRUM-256)

Companion to SCRUM-212, which guarded *where* the seed may run. This one is about the correctness of the data it produces.

## Why

Seeded requests had `conversationId: null` and no messages, so messaging could not be exercised locally at all — `MessagePanel` had nothing to render and `sendMessage` fell into its broken `if (!conversation)` branch. And `deleteAllData` never cleared `Conversation`, so every re-seed left the previous run's conversations behind pointing at deleted requests. With `relationMode = "prisma"` there is no database-level foreign key to stop that, and `Conversation.requestId` is `@unique`, so the ghosts accumulated silently.

## Acceptance criteria

| AC | Status |
| --- | --- |
| Seeded requests have a linked conversation with at least one message | Done — conversation plus a two-sided, partly unread thread |
| `deleteAllData` clears `conversation`; a repeat seed leaves no orphans | Done, verified against real MySQL |
| Redundant `clearConnections` call removed | Done — function deleted, not just the call |
| Per-user seed failures fail the run | Done — the `try/catch` now rethrows with the user id and `cause` |
| `generateUser`'s signature matches what it uses | Done — takes `{ id }`, cast removed |
| Consider caching or stubbing reverse geocoding | Done — offline by default, opt-in Mapbox with per-coordinate caching |

## What changed

**Requests now mirror `requests.create`** (`src/server/router/user/requests.ts`): empty `message` column on the request, conversation keyed by `requestId`, request back-linked via `conversationId`, greeting in a `Message` row. A reply from the recipient is added as well and left unread, so a developer gets a thread and an unread indicator rather than the bare minimum.

**Addresses moved to `src/utils/seedAddresses.ts`** and are synthesised offline, deterministically. Seeding now makes **no network calls and consumes no Mapbox quota**; `SEED_REVERSE_GEOCODE=1` opts back in, cached per coordinate.

This is strictly better than what it replaces, which is worth stating plainly: **without a Mapbox token, every one of the ~140 calls failed and returned the same hardcoded `123 Main St, Boston, MA`** — all 70 users shared one address, and location de-duplication was meaningless. The Mapbox feature parsing is preserved verbatim (including its building-number and POI quirks) and is now unit tested.

**`main()` is behind `require.main === module`**, so the module can be imported without seeding. `prisma db seed` runs it as a script and is unaffected.

## Validation

`yarn lint`, `yarn tsc`, `yarn test` (69 passing, 26 new), `yarn check:env` and `prettier --check` all pass.

**Verified against a real throwaway MySQL 8 container** with migrations applied, by importing the helpers directly — **not** by running the seed, which is denied in `.claude/settings.json` and which I did not work around. Every check passed:

- `request.conversationId` is populated and `conversation.requestId` points back
- `request -> conversation -> messages` resolves in one query, the way the app queries it
- the thread is two-sided, the first message is the requester's, one is unread
- after `deleteAllData` every table is empty, `conversation` included
- a second seed round succeeds with no `requestId @unique` collision
- **the previous delete order does leave an orphaned conversation** — the reported bug reproduced, then shown fixed
- importing the module seeds nothing, confirming the `require.main` guard

## Discovered, not fixed here

A database built from migration history alone **lacks `user.tutorial_completed`** — the field is in `schema.prisma` with no migration creating it, so `prisma.user.create` fails with `P2022`. This blocked verification until I applied the one statement `prisma migrate diff` generates, to the throwaway container only. Already tracked as **SCRUM-227**; deliberately not pulled into this PR.

## Known limitations and risks

- **The full `yarn seed` was never executed.** Seed commands are deny-listed. The helpers are verified individually against real MySQL and the pure logic is unit tested, but no one has watched all 70 users seed end to end. **Worth one manual `yarn seed` against a local database before merging.**
- **`request.message` changes from `"Hello"` to `""`.** That matches what the application writes; the greeting now lives in the `Message` row. Nothing in `src/` appeared to read `request.message`, but a reviewer who knows the UI should sanity-check that.
- **Seeded addresses are now synthetic**, not real Mapbox results. Deliberate, but it does mean local addresses no longer correspond to real streets at those coordinates. Set `SEED_REVERSE_GEOCODE=1` if you need genuine geocoding.
- **Not addressed, and pre-existing:** `pickConnection` can produce both `A -> B` and `B -> A`, whereas `requests.create` rejects a second request between the same pair with `CONFLICT`. Seeded data can therefore contain a pair the app considers impossible. Out of scope here; say the word and I will file it.
- Formatting churn in `src/utils/recommendation.ts` (two hunks) is the pre-commit hook reformatting an already-unformatted file.
- `yarn test` covers the address module only — not the database-writing helpers, which have no test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)