### PR TITLE
SCRUM-266: hold Prisma at v4 in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,30 @@ updates:
     # are yanked or found to be compromised have time to be withdrawn.
     cooldown:
       default-days: 7
+    # Version ceilings, applied before grouping — a package listed here is
+    # filtered out of its group's pull request rather than pinning the group.
+    #
+    # Prisma is held at v4 (SCRUM-266). Without a ceiling the `prisma` group
+    # proposes 4.x -> 7.x in one pull request: three majors, and a migration
+    # project rather than a dependency bump. The group is kept below so the two
+    # packages still move together whenever the pin is lifted.
+    #
+    # 4.16.2 is the final 4.x release, so nothing further will be offered in
+    # practice. Scoping to majors rather than ignoring Prisma outright states
+    # the intent — "stay on this major" — and would still admit a backported
+    # 4.x patch if one ever shipped.
+    #
+    # Caveat: `ignore` suppresses security pull requests too. Because v4 is end
+    # of life, a Prisma advisory would only ever be fixed in v5+, so no
+    # automated PR will appear for one. Alerts still surface in the Security
+    # tab; acting on one means deliberately lifting this pin.
+    ignore:
+      - dependency-name: "prisma"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@prisma/client"
+        update-types:
+          - "version-update:semver-major"
     groups:
       # These packages are coupled and have to move together — bumping one
       # without its siblings breaks the build, so these groups deliberately
@@ -36,6 +60,9 @@ updates:
       aws-sdk:
         patterns:
           - "@aws-sdk/*"
+      # Prisma is the exception to the "majors included" note above: the ignore
+      # rule holds it at v4, so this group only ever carries 4.x updates until
+      # that pin is lifted.
       prisma:
         patterns:
           - "prisma"


### PR DESCRIPTION
Stops Dependabot proposing major Prisma upgrades, per the decision to stay on Prisma v4.

## Why

The `prisma` group added in SCRUM-181 has no version ceiling, so it produced **PR #63** — `prisma` and `@prisma/client` from `^4.14.1` / `^4.4.0` to **`^7.9.1`**. That's three majors in one PR: Prisma 5 changed the client engine, 6 added further breaking changes, and 7 is a substantially rewritten client. It's a migration project, not a dependency bump.

Without a ceiling that PR gets regenerated every Monday and closed by hand each time.

## What changed

One file, `.github/dependabot.yml`. No `package.json` or `yarn.lock` change — **nothing is upgraded or downgraded by this PR**.

```yaml
ignore:
  - dependency-name: "prisma"
    update-types:
      - "version-update:semver-major"
  - dependency-name: "@prisma/client"
    update-types:
      - "version-update:semver-major"
```

## Why major-scoped rather than a blanket ignore

Current state: both packages resolve to **4.16.2**, which is the **last 4.x ever published** — Prisma v4 is EOL. So a major-scoped ignore and a blanket ignore behave identically today.

Major-scoped is still the better spelling:

- it records the constraint as *"stay on this major"* rather than *"never touch Prisma"*, which is what was actually decided
- it would still admit a backported 4.x patch if one ever shipped
- lifting it later is deleting two entries, not re-deriving the original intent

The `prisma` group is deliberately **kept**, so the two packages still move together whenever the pin comes off. A comment reconciles it with the group block's existing "majors included" note, which would otherwise now contradict the ignore rule.

## Caveat recorded in the config

Dependabot `ignore` suppresses **security** PRs as well as version updates. Because v4 is EOL, a Prisma advisory would only ever be fixed in v5+, so no automated PR will appear for one. Dependabot *alerts* still surface in the Security tab — only the automated PR is suppressed. Acting on a Prisma advisory becomes a deliberate decision to lift the pin. That trade-off is written into the file rather than left implicit.

## Verification

`ignore` is evaluated before grouping, so a listed package is filtered out of its group's PR rather than pinning the whole group. I simulated the rule against real and hypothetical bumps:

| package | bump | class | result |
|---|---|---|---|
| `prisma` | 4.16.2 → 7.9.1 | major | **BLOCKED** — this is PR #63 |
| `@prisma/client` | 4.16.2 → 7.9.1 | major | **BLOCKED** |
| `prisma` | 4.16.2 → 5.0.0 | major | **BLOCKED** |
| `prisma` | 4.16.2 → 4.17.0 | minor | allowed |
| `prisma` | 4.16.2 → 4.16.3 | patch | allowed |

Also confirmed: the `prisma` rule does not leak onto `@prisma/client` (exact names, both listed explicitly), no other package is affected, and the `github-actions` update block is untouched.

Config parses as valid YAML with the expected structure, and `prettier --check` is clean.

## Follow-up

Once this is on `main`, Dependabot closes **PR #63** automatically on its next scheduled run (Mondays 06:00 ET). It can be closed by hand sooner if you'd rather not wait.

Prisma v4 → v7, when the team wants it, should be its own scoped ticket — note SCRUM-227 (migration history does not reproduce `schema.prisma`) is unresolved and would want sorting first. Broader dependency review is SCRUM-136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)