### PR TITLE
SCRUM-235: measure schedule difference from total minutes

### DIFF
--- a/src/utils/recommendation.test.ts
+++ b/src/utils/recommendation.test.ts
@@ -271,14 +271,95 @@ describe("calculateScore", () => {
       ).toBe(true);
     });
 
-    it("compares hours and minutes separately, reading 9:50 vs 10:00 as 110 minutes apart (SCRUM-235)", () => {
+    it("reads 9:50 vs 10:00 as 10 minutes apart, not 110 (SCRUM-235)", () => {
       const current = rider({ startTime: at(9, 50), endTime: at(17) });
       const candidate = driver({ startTime: at(10, 0), endTime: at(17) });
 
-      // A true 10 minute gap would clear a 1 hour cutoff. This implementation
-      // computes |9-10| * 60 + |50-0| = 110 minutes and rejects the pair.
-      expect(isMatch(current, candidate, { startTime: 1 })).toBe(false);
-      expect(isMatch(current, candidate, { startTime: 2 })).toBe(true);
+      // The pair is 10 minutes apart, so it clears every cutoff the UI offers,
+      // down to the tightest. The previous implementation computed
+      // |9-10| * 60 + |50-0| = 110 minutes and rejected this at a 1 hour cutoff.
+      expect(isMatch(current, candidate, { startTime: 1 })).toBe(true);
+      expect(isMatch(current, candidate, { startTime: 0.25 })).toBe(true);
+    });
+
+    it.each([
+      {
+        label: "minutes running backwards across the hour",
+        currentStart: at(9, 50),
+        candidateStart: at(10, 0),
+        minutes: 10,
+      },
+      {
+        label: "minutes running forwards across the hour",
+        currentStart: at(8, 45),
+        candidateStart: at(9, 15),
+        minutes: 30,
+      },
+      {
+        label: "a whole hour on the same minute",
+        currentStart: at(9, 0),
+        candidateStart: at(10, 0),
+        minutes: 60,
+      },
+      {
+        label: "the same time",
+        currentStart: at(9, 0),
+        candidateStart: at(9, 0),
+        minutes: 0,
+      },
+      {
+        label: "minutes only, within one hour",
+        currentStart: at(9, 15),
+        candidateStart: at(9, 45),
+        minutes: 30,
+      },
+      {
+        label: "a candidate earlier than the current user",
+        currentStart: at(10, 0),
+        candidateStart: at(9, 50),
+        minutes: 10,
+      },
+    ])(
+      "measures $label as $minutes minutes, at the filter boundary",
+      ({ currentStart, candidateStart, minutes }) => {
+        const current = rider({ startTime: currentStart, endTime: at(17) });
+        const candidate = driver({
+          startTime: candidateStart,
+          endTime: at(17),
+        });
+
+        // The filter excludes when the difference is strictly greater than the
+        // cutoff, so a cutoff of exactly the true gap keeps the pair and one
+        // minute below it drops them. That brackets the value from both sides.
+        expect(isMatch(current, candidate, { startTime: minutes / 60 })).toBe(
+          true,
+        );
+
+        if (minutes > 0) {
+          expect(
+            isMatch(current, candidate, { startTime: (minutes - 1) / 60 }),
+          ).toBe(false);
+        }
+      },
+    );
+
+    it("applies the same measurement to the end time", () => {
+      // The end time runs through the same helper; this guards against the fix
+      // being applied to only one of the two.
+      const current = rider({ startTime: at(9), endTime: at(16, 50) });
+      const candidate = driver({ startTime: at(9), endTime: at(17, 0) });
+
+      expect(isMatch(current, candidate, { endTime: 10 / 60 })).toBe(true);
+      expect(isMatch(current, candidate, { endTime: 9 / 60 })).toBe(false);
+    });
+
+    it("scores a 10 minute gap far better than the old arithmetic did", () => {
+      // Scoring reads the same value as the filter, so the correction has to
+      // show up in the score too: 10/80 of the start-time weight, not 80/80.
+      const current = rider({ startTime: at(9, 50), endTime: at(17) });
+      const candidate = driver({ startTime: at(10, 0), endTime: at(17) });
+
+      expect(score(current, candidate)).toBeCloseTo((10 / 80) * 0.1);
     });
   });
 

--- a/src/utils/recommendation.ts
+++ b/src/utils/recommendation.ts
@@ -46,6 +46,28 @@ export type FInputs = {
 /** Provides a very approximate coordinate distance to mile conversion */
 const coordToMile = (dist: number) => dist * 88;
 
+/**
+ * Minutes between two times of day (SCRUM-235).
+ *
+ * Both times are collapsed to a minute offset from midnight before subtracting.
+ * The previous form — |Δhours| * 60 + |Δminutes| — took the absolute value of
+ * each component separately, so a pair whose minutes ran backwards relative to
+ * its hours was overstated: 9:50 against 10:00 read as 110 minutes rather than
+ * 10. That inflated difference both filtered out compatible users and penalised
+ * their score.
+ *
+ * Only the clock reading is used, so the caller's date is irrelevant — which
+ * suits `startTime`/`endTime`, stored as `@db.Time(0)` with no date component.
+ * The two readings are taken through the same accessor, so a shared timezone
+ * offset cancels in the subtraction; the underlying storage ambiguity is
+ * SCRUM-239 and is deliberately not addressed here.
+ */
+const minutesApart = (a: Date, b: Date) => {
+  const minutesOfDay = (time: Date) => time.getHours() * 60 + time.getMinutes();
+
+  return Math.abs(minutesOfDay(a) - minutesOfDay(b));
+};
+
 interface CommonUser {
   id: string;
   role: string;
@@ -170,16 +192,8 @@ export const calculateScore = (
       user.startTime &&
       user.endTime
     ) {
-      startTime =
-        Math.abs(currentUser.startTime.getHours() - user.startTime.getHours()) *
-          60 +
-        Math.abs(
-          currentUser.startTime.getMinutes() - user.startTime.getMinutes(),
-        );
-      endTime =
-        Math.abs(currentUser.endTime.getHours() - user.endTime.getHours()) *
-          60 +
-        Math.abs(currentUser.endTime.getMinutes() - user.endTime.getMinutes());
+      startTime = minutesApart(currentUser.startTime, user.startTime);
+      endTime = minutesApart(currentUser.endTime, user.endTime);
       if (
         (startTime > inputs.startTime * 60 && inputs.startTime < 4) ||
         (endTime > inputs.endTime * 60 && inputs.endTime < 4)


### PR DESCRIPTION
[SCRUM-235](https://carpoolnu.atlassian.net/browse/SCRUM-235)

## Purpose

The start/end time gap that drives both the recommendation **filter** and the time component of the **score** was computed as `|Δhours| * 60 + |Δminutes|` — taking the absolute value of each component separately. Whenever the minutes run backwards relative to the hours, the result is overstated:

| A | B | Correct | Old formula |
|---|---|---|---|
| 09:50 | 10:00 | 10 min | **110 min** |
| 08:45 | 09:15 | 30 min | **90 min** |
| 09:00 | 10:00 | 60 min | 60 min ✅ |

This is the common case, not an edge case. The profile form offers times in 15-minute steps (`ControlledTimePicker` `minuteStep={15}`), so minute-crossing pairs are the norm.

## Impact, measured

Over the 15-minute grid across a realistic 06:00–11:00 commute band (576 ordered pairs):

| Cutoff | Old admits | New admits | Newly visible |
|---|---|---|---|
| 0.5 h | 84 (14.6%) | 114 (19.8%) | 30 |
| **1 h** | **136 (23.6%)** | **196 (34.0%)** | **60** |
| 2 h | 288 (50.0%) | 336 (58.3%) | 48 |

At a 1-hour filter that is a **44% relative increase** in candidates a user can see.

The change is **monotone**: no pair the old formula admitted is rejected by the new one. This only widens results — it cannot hide someone who was previously visible.

## Changes

**`src/utils/recommendation.ts`** — both readings collapse to a minute offset from midnight before subtracting, via a new `minutesApart` helper placed alongside the existing `coordToMile`.

**`src/utils/recommendation.test.ts`** — the existing test that *pinned the old arithmetic* is replaced by one asserting the intended behaviour, plus:
- a table of six cases: minutes backwards across the hour, minutes forwards across the hour, a whole hour, an identical time, a sub-hour gap, and a candidate earlier than the current user — each bracketed at the filter boundary (cutoff = exact gap passes, one minute below fails)
- the end time uses the same measurement, guarding against the fix being applied to only one of the two
- the correction reaches the **score**, not just the filter

## Acceptance criteria

- [x] Time difference is computed from total minutes
- [x] 09:50 vs 10:00 is treated as 10 minutes apart by both the filter and the score
- [x] A unit test covers a minute-crossing pair and a same-minute pair
- [ ] **Spot-checked against the time filter in the UI** — see below

## Validation

| Check | Result |
|---|---|
| `yarn test` | 288 passed, 11 suites (76 in `recommendation.test.ts`) |
| `yarn tsc` | clean |
| `yarn lint` | clean (`--max-warnings=0`) |
| `npx prettier --check` | clean |

**Tests confirmed to have teeth:** against the pre-fix implementation from `origin/main`, **6 of 76 tests fail**. The 3 whole-hour cases correctly still pass, since the old formula got those right — which is exactly the signature of this bug.

## Limitations

- **The UI spot-check acceptance criterion is not met.** Running the map against real data needs a database, a Mapbox token and Azure AD sign-in, none of which are available here. In its place I measured the filter predicate directly over the 15-minute grid the form produces (the table above) — reproducible and quantified, but it is not the same as clicking through the app. **A reviewer should confirm on staging that the sidebar and map widen as expected.**
- Scoring is exercised through `calculateScore` with fixture data, not against real rows. Real-database coverage is SCRUM-263.
- **Out of scope, still present in this function:** `NaN` scores when the filter records no working days, distance and days each counted twice in `finalScore`, and Euclidean distance in degree space. All tracked in **SCRUM-236**, which the ticket deliberately splits out so this user-visible exclusion bug can ship alone. The tests pinning that behaviour (`...(SCRUM-236)`) are left untouched and still pass.
- Storage-level timezone ambiguity for `@db.Time(0)` is **SCRUM-239** and is untouched. Both readings go through the same accessor, so a shared offset cancels in the subtraction.

## Notes

No pre-existing working-tree changes were excluded — the tree was clean at branch creation. This branch is based on `main` after PR #87 (SCRUM-223) was merged, so `favorites.test.ts` in the suite output comes from the base, not from this PR. The diff is exactly two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)