### PR TITLE
SCRUM-136: remove unused react-infinite-scroll-component (supersedes #84)

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "react-easy-crop": "5.5.3",
     "react-hook-form": "7.85.0",
     "react-icons": "4.12.0",
-    "react-infinite-scroll-component": "^6.1.0",
     "react-query": "^3.39.1",
     "react-toast-notifications": "^2.5.1",
     "react-toastify": "^9.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6965,13 +6965,6 @@ react-icons@4.12.0:
   resolved "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz"
   integrity sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==
 
-react-infinite-scroll-component@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz"
-  integrity sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==
-  dependencies:
-    throttle-debounce "^2.1.0"
-
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
@@ -7846,11 +7839,6 @@ thenify-all@^1.0.0:
   integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
   dependencies:
     any-promise "^1.0.0"
-
-throttle-debounce@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz"
-  integrity sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==
 
 throttle-debounce@^5.0.0, throttle-debounce@^5.0.2:
   version "5.0.2"


### PR DESCRIPTION
[SCRUM-136](https://carpoolnu.atlassian.net/browse/SCRUM-136)

**Supersedes Dependabot [#84](https://github.com/CarpoolNU/nucarpool/pull/84)**, which bumps this package 6.1.0 → 7.2.1. That upgrade is safe but pointless — nothing imports it. Removing it is the better resolution.

## Investigation

I checked history rather than assuming zero current imports meant it was never used. It **was** used, briefly:

| | |
|---|---|
| **Added** | 2023-01-29, `c272fda` (PR #19, "Backend changes for favorites") |
| **Last used** | 2023-02-16, `b49cef7` (PR #24, "Sidebar and dashboard changes to match new design") |
| **Orphaned for** | ~3.5 years |

`src/components/Sidebar.tsx` wrapped the user list in `<InfiniteScroll>`. Notably it **never actually paginated**:

```jsx
<InfiniteScroll
  dataLength={curList.length}
  next={() => { return; }}   // no-op
  hasMore={false}            // never loads more
  ...
>
  {curList.map(userToElem)}
</InfiniteScroll>
```

It was a scroll container around an already-complete list. PR #24 rewrote the sidebar into `UserCard.tsx` and dropped the import — but **did not touch `package.json`**, so the dependency was left behind.

A pickaxe search (`git log --all -S "InfiniteScroll"`) returns exactly those two commits: introduced once, used inertly, abandoned. The only remaining repo match for "infinite" outside `package.json`/`yarn.lock` is an unrelated CSS keyword in `tailwind.config.js:40`.

**Classification: historical leftover.**

## No active work depends on it

I searched Jira for infinite scroll / pagination / scroll. The two live hits — **SCRUM-245** (map and recommendation queries load every active search) and **SCRUM-246** (admin analytics read whole tables unpaginated) — are both about **bounding database queries server-side**, not a client-side scroll component. Neither names this package. SCRUM-126 and SCRUM-166 are Done and unrelated.

## Changes

One line out of `package.json`, plus the lockfile regenerated by `yarn remove` (not hand-edited).

**Dependency tree impact:** the package's only transitive dependency, `throttle-debounce@^2.3.0`, drops out with it. `throttle-debounce@^5.0.2` remains for other consumers — verified before and after.

## Validation

| Check | Result |
|---|---|
| `yarn install --frozen-lockfile` | pass — lockfile consistent |
| `yarn lint` | pass (`--max-warnings=0`) |
| `yarn tsc` | pass |
| `yarn test` | 288 passed, 11 suites |
| `yarn build` | pass — real `next build`, all routes emitted |
| `yarn check:env` | pass |

Confirmed no imports or runtime references remain.

## Notes

`yarn remove` also re-sorted an unrelated `devDependencies` line (`@types/mapbox__polyline` / `@types/mapbox-gl`). I reverted that so the diff is purely the removal; it is cosmetic and will likely reappear the next time anyone runs `yarn add`/`yarn remove`.

**Related, deliberately not included:** the SCRUM-136 comment thread already records four more zero-import packages — `@mui/x-date-pickers`, `react-query` v3, `@trpc/react` v9, `@mui/icons-material`. Removing those is a larger change (`react-query` v3 vs `@tanstack/react-query` needs care) and belongs in its own PR.

**Action on #84:** leave it open until this merges, then close it as superseded. I have not closed or merged anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)